### PR TITLE
Enforce literature exploration batches in Auto-FL campaigns

### DIFF
--- a/docs/design/autofl_skill.md
+++ b/docs/design/autofl_skill.md
@@ -135,10 +135,22 @@ standard NVFlare job lifecycle.
 The built-in parameter candidates are suggestion seeds only. They are returned
 as machine-readable hypotheses and arguments when requested, but are not the
 default search loop and are never executed without agent selection.
-After each literature-triggered plateau, campaign state requests at least one
-source-backed server aggregation candidate under the same comparison budget.
-When the job contract makes that impossible, the agent records the reason in
-the literature event instead of silently omitting aggregation exploration.
+Each recorded literature review receives a persistent `literature_event_id`
+(`lit-0001` style). After a review is recorded, campaign state requires an
+exploration batch: `exploration_batch_size` scored source-backed candidates
+(default 3, flag `--exploration-batch-size`, env
+`AUTOFL_EXPLORATION_BATCH_SIZE`) linked to that review under the same
+comparison budget before normal candidate flow resumes. `prepare` accepts
+`--family` for the algorithm-family slug and `--literature-event` for the
+review link; both are persisted in `candidate_manifest.json` and as the
+`candidate_kind`, `algorithm_family`, and `literature_event_id` columns in
+`results.tsv`. A literature-linked candidate must contain source edits; the
+runner rejects argument-only literature-linked candidates at evaluate time.
+Qualifying exploration is not limited to server aggregation: client optimizer,
+loss function, learning-rate schedule, and architecture candidates within the
+fixed comparison budget count equally. When the job contract makes
+source-backed exploration impossible, the agent records the reason in the
+literature event instead of silently omitting it.
 
 ## Execution Model
 
@@ -165,6 +177,19 @@ campaign guard is a read-only diagnostic and cannot overwrite runner metadata.
 A stop file takes immediate precedence: pending candidates must be safely
 abandoned before final reporting. Without a stop request, pending prepared or
 externally ready candidates take precedence over cap exhaustion and reporting.
+
+Campaign state enforces the exploration batch deterministically. After a
+literature review is recorded, state reports
+`next_action=develop_literature_batch` and
+`required_exploration=source_backed_exploration` until the review's batch of
+linked scored candidates completes. The plateau counter resets only when that
+batch completes — when its final linked scored candidate records — not when
+the review row is recorded. After the first literature event, if the last
+`family_repeat_limit` scored attempts (default 6, flag `--family-repeat-limit`,
+env `AUTOFL_FAMILY_REPEAT_LIMIT`, 0 disables) are all argument-only tuning of
+the same algorithm family, state reports `next_action=diversify_candidates`.
+The `progress.png` plot renders source-edited candidates distinctly from
+argument-only candidates and annotates literature-linked families.
 
 Every score must be finite and records its metric name, extraction source, and
 artifact. Structured metric artifacts take precedence over text fallback, which

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -42,8 +42,14 @@ Read `autofl.yaml` and the JSON response, then prepare an agent-authored
 candidate with a short hypothesis and optional candidate-only arguments:
 
 ```bash
-python "$RUNNER" prepare ./job.py --name <candidate> --hypothesis "<expected improvement>" [--run-args "<args>"]
+python "$RUNNER" prepare ./job.py --name <candidate> --hypothesis "<expected improvement>" [--run-args "<args>"] [--family <slug>] [--literature-event <id>]
 ```
+
+Pass `--family` with an algorithm-family slug (for example `fedyogi` or
+`adaptive-clipping`) and `--literature-event` with the review's
+`literature_event_id` when the candidate implements a literature idea. Both are
+persisted in `candidate_manifest.json` and as the `candidate_kind`,
+`algorithm_family`, and `literature_event_id` columns in `results.tsv`.
 
 Edit only the returned candidate source directory. Modify existing allowed
 files or add Python modules under the job root; do not edit the live best source
@@ -141,8 +147,9 @@ specific fields before running candidates.
 3. Prepare a candidate, edit its draft, and evaluate its manifest.
 4. Let the helper validate paths and fixed-budget comparability, compute the
    patch hash, execute or materialize it, extract metrics, and keep or restore.
-5. Read campaign state and execute `next_action`. Run a source-backed literature
-   pass when requested, then implement its strongest compatible idea.
+5. Read campaign state and execute `next_action`. When it requests a literature
+   pass, run it, record it, then complete the full source-backed exploration
+   batch linked to that review before resuming normal candidate flow.
 
 ## Continuous Campaign Rule
 For uncapped campaigns, continue proposing and evaluating same-budget candidates
@@ -185,9 +192,39 @@ next mode, and continue unless the state reports `final_response_allowed=true`.
 Use `campaign_guard.py` only for read-only ledger diagnostics; it never updates
 authoritative campaign state.
 After a source-backed review, record it with the helper's `record --literature
---hypothesis "<sources and decision>"` action before preparing its candidate.
-After every literature-triggered plateau, evaluate at least one source-backed
-server aggregation candidate, or record why the job contract is incompatible.
+--hypothesis "<sources and decision>"` action before preparing its candidates.
+Each recorded review gets a persistent `literature_event_id` (`lit-0001` style).
+
+## Literature Exploration Batches
+
+A recorded literature review requires an exploration batch:
+`exploration_batch_size` (default 3, flag `--exploration-batch-size`, env
+`AUTOFL_EXPLORATION_BATCH_SIZE`) scored source-backed candidates linked to that
+review via `prepare --literature-event <id>` before normal candidate flow
+resumes. Campaign state keeps `next_action=develop_literature_batch` and
+`required_exploration=source_backed_exploration` until the batch completes.
+Compose the batch as a faithful implementation of the literature idea, a tuned
+variant, and an ablation. Every literature-linked candidate must contain
+source edits; the runner rejects argument-only literature-linked candidates at
+evaluate time.
+
+The plateau clock resets only when the exploration batch completes — when its
+final linked candidate scores — not when the review row is recorded. Recording
+a review does not relieve plateau pressure. After the first literature event,
+if the last `family_repeat_limit` (default 6, flag `--family-repeat-limit`,
+env `AUTOFL_FAMILY_REPEAT_LIMIT`, 0 disables) scored attempts are all
+argument-only tuning of the same algorithm family, campaign state sets
+`next_action=diversify_candidates`: switch to a different algorithm family or
+prepare a source-backed candidate.
+
+Select literature ideas for the workload, not only for server aggregation:
+client optimizer, loss function, learning-rate schedule, and architecture
+changes within the fixed comparison budget all qualify as source-backed
+exploration. Match the workload's threat model: do not select Byzantine-robust
+aggregation (geometric median, trimmed mean, sign gating, bucketed median) for
+benign-client campaigns, where it predictably sacrifices accuracy with no
+adversary present. If no source-backed exploration is compatible with the job
+contract, record the reason in the literature event.
 
 ## Stop Handling
 

--- a/skills/nvflare-autofl/references/continuous-campaigns.md
+++ b/skills/nvflare-autofl/references/continuous-campaigns.md
@@ -47,13 +47,35 @@ Common next actions:
   lifecycle, then call `record` with its job ID and artifacts.
 - `rerun_with_escalated_execution`: retry the same lifecycle action after
   repairing runtime permissions; do not count it as a candidate.
-- `run_literature_loop`: run a short source-backed literature pass, record a
-  non-scored `literature` row when a ledger is available, then launch the next
-  compatible same-budget candidates. Include at least one source-backed server
-  aggregation candidate; if that is incompatible with the job contract,
-  record the reason in the literature event.
+- `run_literature_loop`: run a short source-backed literature pass and record
+  it with `record --literature`; the runner assigns a persistent
+  `literature_event_id` (`lit-0001` style) and a non-scored `literature` ledger
+  row. Select ideas that fit the workload: client optimizer, loss function,
+  learning-rate schedule, architecture, and server aggregation changes within
+  the fixed comparison budget all qualify as source-backed exploration. Match
+  the workload's threat model — do not select Byzantine-robust aggregation
+  (geometric median, trimmed mean, sign gating, bucketed median) for
+  benign-client campaigns. If no source-backed exploration is compatible with
+  the job contract, record the reason in the literature event.
+- `develop_literature_batch`: the latest review's exploration batch is
+  incomplete. Prepare and evaluate scored source-backed candidates linked to
+  the review via `prepare --family <slug> --literature-event <id>` until
+  `exploration_batch_size` of them (default 3, flag `--exploration-batch-size`,
+  env `AUTOFL_EXPLORATION_BATCH_SIZE`) have scored; state keeps
+  `required_exploration=source_backed_exploration` until then. Compose the
+  batch as a faithful implementation of the literature idea, a tuned variant,
+  and an ablation. Literature-linked candidates must contain source edits; the
+  runner rejects argument-only literature-linked candidates at evaluate time.
+- `diversify_candidates`: the last `family_repeat_limit` scored attempts
+  (default 6, flag `--family-repeat-limit`, env `AUTOFL_FAMILY_REPEAT_LIMIT`,
+  0 disables) were all argument-only tuning of the same algorithm family.
+  Switch to a different algorithm family or prepare a source-backed candidate.
 - `final_report`: generate final artifacts only after the runner permits a final
   response.
+
+The plateau clock resets when a literature review's exploration batch
+completes — when its final linked candidate scores — not when the review row
+is recorded. Recording a review does not relieve plateau pressure.
 
 After every finalized batch, run the available plateau or progress watchdog when
 the task provides one. If it recommends `continue`, refresh `progress.png` and
@@ -67,7 +89,10 @@ request deterministic tunable suggestions as seeds.
 Server aggregation is an open code-search surface. The agent may create a new
 Python aggregator module, edit an existing allowed aggregator module, and
 register it through `job.py`; it must not limit exploration to the job's
-pre-existing FedAvg, FedAvgM, FedAdam, FedOpt, or SCAFFOLD options.
+pre-existing FedAvg, FedAvgM, FedAdam, FedOpt, or SCAFFOLD options. Required
+source-backed exploration is not aggregation-only: client optimizer, loss
+function, learning-rate schedule, and architecture candidates within the fixed
+comparison budget qualify equally.
 
 ## Simulator Recovery
 

--- a/skills/nvflare-autofl/scripts/campaign_guard.py
+++ b/skills/nvflare-autofl/scripts/campaign_guard.py
@@ -33,6 +33,8 @@ from typing import Any, Dict, List, Optional, Tuple
 DEFAULT_HARD_CRASH_THRESHOLD = 6
 DEFAULT_MIN_DELTA = 0.0005
 DEFAULT_PLATEAU_THRESHOLD = 8
+DEFAULT_EXPLORATION_BATCH_SIZE = 3
+DEFAULT_FAMILY_REPEAT_LIMIT = 6
 DEFAULT_STOP_FILES = ("STOP_AUTOFL", ".nvflare/autofl/STOP")
 ATTEMPT_STATUSES = {"candidate", "keep", "discard", "crash"}
 SCORED_ATTEMPT_STATUSES = {"keep", "discard"}
@@ -79,6 +81,27 @@ def is_literature_event(row: Dict[str, str]) -> bool:
     return "literature" in (row.get("name", "") or "").lower()
 
 
+def candidate_kind(row: Dict[str, str]) -> str:
+    kind = (row.get("candidate_kind", "") or "").strip().lower()
+    if kind:
+        return kind
+    changed = (row.get("changed_files", "") or "").strip().lower()
+    return "source_edit" if changed and changed != "none" else "argument_only"
+
+
+def algorithm_family(row: Dict[str, str]) -> str:
+    return (row.get("algorithm_family", "") or "").strip().lower()
+
+
+def literature_events(rows: List[Dict[str, str]]) -> List[Tuple[int, str]]:
+    events = []
+    for idx, row in enumerate(rows):
+        if is_literature_event(row):
+            event_id = (row.get("literature_event_id", "") or "").strip() or f"lit-{len(events) + 1:04d}"
+            events.append((idx, event_id))
+    return events
+
+
 def comparable_attempts(rows: List[Dict[str, str]]) -> List[Dict[str, str]]:
     return [row for row in rows if normalize_status(row) in ATTEMPT_STATUSES and not is_baseline(row)]
 
@@ -110,6 +133,51 @@ def scored_attempts_with_index(rows: List[Dict[str, str]]) -> List[Tuple[int, Di
     return scored_rows_with_index(rows, is_scored_attempt)
 
 
+def exploration_batches(rows: List[Dict[str, str]], batch_size: int) -> List[Dict[str, Any]]:
+    """Per literature event: linked scored source-edited candidates and the batch-completion row index."""
+    events = literature_events(rows)
+    scored = scored_attempts_with_index(rows)
+    batches = []
+    for position, (event_idx, event_id) in enumerate(events):
+        next_event_idx = events[position + 1][0] if position + 1 < len(events) else len(rows)
+        linked = []
+        for row_idx, row, _ in scored:
+            if row_idx <= event_idx or candidate_kind(row) != "source_edit":
+                continue
+            row_event = (row.get("literature_event_id", "") or "").strip()
+            if row_event == event_id or (not row_event and row_idx < next_event_idx):
+                linked.append(row_idx)
+        if batch_size <= 0:
+            completion_index: Optional[int] = event_idx
+        elif len(linked) >= batch_size:
+            completion_index = sorted(linked)[batch_size - 1]
+        else:
+            completion_index = None
+        batches.append(
+            {
+                "literature_event_id": event_id,
+                "event_index": event_idx,
+                "required": max(batch_size, 0),
+                "completed": len(linked),
+                "completion_index": completion_index,
+            }
+        )
+    return batches
+
+
+def family_repeat_stalled(rows: List[Dict[str, str]], limit: int) -> bool:
+    if limit <= 0 or not literature_events(rows):
+        return False
+    scored = scored_attempts_with_index(rows)
+    if len(scored) < limit:
+        return False
+    recent = [row for _, row, _ in scored[-limit:]]
+    families = {algorithm_family(row) for row in recent}
+    if len(families) != 1 or not next(iter(families)):
+        return False
+    return all(candidate_kind(row) == "argument_only" for row in recent)
+
+
 def better(new_score: Optional[float], old_score: Optional[float], mode: str, min_delta: float = 0.0) -> bool:
     new_score = parse_score(new_score)
     old_score = parse_score(old_score)
@@ -130,7 +198,13 @@ def best_score(rows: List[Dict[str, str]], mode: str) -> Optional[float]:
     return best
 
 
-def plateau_status(rows: List[Dict[str, str]], threshold: int, min_delta: float, mode: str) -> Dict[str, Any]:
+def plateau_status(
+    rows: List[Dict[str, str]],
+    threshold: int,
+    min_delta: float,
+    mode: str,
+    exploration_batch_size: int = DEFAULT_EXPLORATION_BATCH_SIZE,
+) -> Dict[str, Any]:
     retained = scored_rows_with_index(rows, is_retained)
     scored_attempts = scored_attempts_with_index(rows)
     if threshold <= 0 or not retained:
@@ -153,8 +227,15 @@ def plateau_status(rows: List[Dict[str, str]], threshold: int, min_delta: float,
             best_scored_idx = scored_idx
             best_name = row.get("name", "")
 
-    last_literature_idx = max((idx for idx, row in enumerate(rows) if is_literature_event(row)), default=-1)
-    reset_row_idx = max(best_row_idx, last_literature_idx)
+    batches = exploration_batches(rows, exploration_batch_size)
+    last_literature_idx = max((batch["event_index"] for batch in batches), default=-1)
+    # The plateau clock resets when a literature exploration batch COMPLETES, not when the
+    # review is merely recorded — otherwise recording a review relieves plateau pressure
+    # without any source-backed follow-through.
+    last_batch_completion_idx = max(
+        (batch["completion_index"] for batch in batches if batch["completion_index"] is not None), default=-1
+    )
+    reset_row_idx = max(best_row_idx, last_batch_completion_idx)
     scored_since_reset = sum(1 for row_idx, _, _ in scored_attempts if row_idx > reset_row_idx)
     recommendation = "literature" if scored_since_reset >= threshold else "continue"
     return {
@@ -164,6 +245,7 @@ def plateau_status(rows: List[Dict[str, str]], threshold: int, min_delta: float,
         "best_score": best,
         "best_scored_index": best_scored_idx,
         "last_literature_event_index": last_literature_idx,
+        "last_batch_completion_index": last_batch_completion_idx,
         "min_delta": min_delta,
         "reset_row_index": reset_row_idx,
         "scored_since_reset": scored_since_reset,
@@ -211,13 +293,17 @@ def guard_state_for_rows(
     hard_crash_threshold: int = DEFAULT_HARD_CRASH_THRESHOLD,
     mode: str = "max",
     pending_manifest_count: int = 0,
+    exploration_batch_size: int = DEFAULT_EXPLORATION_BATCH_SIZE,
+    family_repeat_limit: int = DEFAULT_FAMILY_REPEAT_LIMIT,
 ) -> Dict[str, Any]:
     attempts = comparable_attempts(rows)
     pending = pending_candidates(rows)
     cap = max_candidates
     cap_source = "explicit" if cap is not None else "uncapped"
     stop_file_hits = existing_stop_files(stop_files or list(DEFAULT_STOP_FILES))
-    plateau = plateau_status(rows, plateau_threshold, min_delta, mode)
+    batches = exploration_batches(rows, exploration_batch_size)
+    active_batch = batches[-1] if batches and batches[-1]["completion_index"] is None else None
+    plateau = plateau_status(rows, plateau_threshold, min_delta, mode, exploration_batch_size)
 
     decision = "continue"
     reason = "continue"
@@ -247,6 +333,12 @@ def guard_state_for_rows(
         reason = "hard_repeated_crash_blocker"
         next_action = "final_report"
         final_response_allowed = True
+    elif active_batch is not None:
+        reason = "literature_exploration_batch"
+        next_action = "develop_literature_batch"
+    elif family_repeat_stalled(rows, family_repeat_limit):
+        reason = "family_repeat_limit"
+        next_action = "diversify_candidates"
     elif plateau.get("recommendation") == "literature":
         reason = "plateau_literature"
         next_action = "run_literature_loop"
@@ -262,9 +354,23 @@ def guard_state_for_rows(
         instruction = "Do not produce a final answer. Finish the pending candidate, then run the runner status action."
     elif next_action == "run_literature_loop":
         instruction = (
-            "Do not produce a final answer. Run the literature loop, record a literature event, "
-            "then launch source-backed candidates under the same comparison budget. Include at least one "
-            "server aggregation candidate when compatible with the job contract; otherwise record why it is incompatible."
+            "Do not produce a final answer. Run the literature loop and record a literature event with "
+            "record --literature. Select a workload-appropriate idea (server aggregation, client optimizer, "
+            "loss, schedule, or architecture within the fixed budget), then develop it as a source-backed "
+            "exploration batch linked via --literature-event."
+        )
+    elif next_action == "develop_literature_batch":
+        remaining = active_batch["required"] - active_batch["completed"]
+        instruction = (
+            f"Do not produce a final answer. Literature event {active_batch['literature_event_id']} needs "
+            f"{remaining} more scored source-backed candidate(s) prepared with --literature-event before normal "
+            "candidate flow resumes: a faithful implementation, a tuned variant, and an ablation under the "
+            "same comparison budget."
+        )
+    elif next_action == "diversify_candidates":
+        instruction = (
+            "Do not produce a final answer. Recent scored attempts are argument-only tuning of a single "
+            "algorithm family; prepare a source-backed candidate or switch to a different family next."
         )
     else:
         instruction = "Do not produce a final answer. Propose and prepare the next same-budget candidate now."
@@ -285,7 +391,10 @@ def guard_state_for_rows(
         "best_score": best_score(rows, mode),
         "stop_files": stop_file_hits,
         "plateau": plateau,
-        "required_exploration": "source_backed_server_aggregation" if next_action == "run_literature_loop" else None,
+        "exploration_batch": batches[-1] if batches else None,
+        "required_exploration": (
+            "source_backed_exploration" if next_action in {"run_literature_loop", "develop_literature_batch"} else None
+        ),
         "agent_instruction": instruction,
     }
 
@@ -300,6 +409,8 @@ def guard_state(
     hard_crash_threshold: int = DEFAULT_HARD_CRASH_THRESHOLD,
     mode: str = "max",
     pending_manifest_count: int = 0,
+    exploration_batch_size: int = DEFAULT_EXPLORATION_BATCH_SIZE,
+    family_repeat_limit: int = DEFAULT_FAMILY_REPEAT_LIMIT,
 ) -> Dict[str, Any]:
     return guard_state_for_rows(
         load_rows(results_path),
@@ -311,6 +422,8 @@ def guard_state(
         hard_crash_threshold=hard_crash_threshold,
         mode=mode,
         pending_manifest_count=pending_manifest_count,
+        exploration_batch_size=exploration_batch_size,
+        family_repeat_limit=family_repeat_limit,
     )
 
 
@@ -344,6 +457,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--plateau-threshold", type=int, default=DEFAULT_PLATEAU_THRESHOLD)
     parser.add_argument("--min-delta", type=float, default=DEFAULT_MIN_DELTA)
     parser.add_argument("--hard-crash-threshold", type=int, default=DEFAULT_HARD_CRASH_THRESHOLD)
+    parser.add_argument("--exploration-batch-size", type=int, default=DEFAULT_EXPLORATION_BATCH_SIZE)
+    parser.add_argument("--family-repeat-limit", type=int, default=DEFAULT_FAMILY_REPEAT_LIMIT)
     parser.add_argument("--mode", choices=["max", "min"], default="max")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
@@ -366,6 +481,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         min_delta=args.min_delta,
         hard_crash_threshold=args.hard_crash_threshold,
         mode=args.mode,
+        exploration_batch_size=args.exploration_batch_size,
+        family_repeat_limit=args.family_repeat_limit,
     )
     if args.format == "json":
         print(json.dumps(state, sort_keys=True))

--- a/skills/nvflare-autofl/scripts/plot_progress.py
+++ b/skills/nvflare-autofl/scripts/plot_progress.py
@@ -45,6 +45,9 @@ class ProgressRecord:
     score: Optional[float]
     runtime_seconds: float
     description: str
+    kind: str = ""
+    family: str = ""
+    literature_event_id: str = ""
 
 
 def load_campaign_guard():
@@ -112,6 +115,16 @@ def record_label(record: ProgressRecord, limit: int) -> str:
     return compact_label(record.name or record.description, limit)
 
 
+def resolve_candidate_kind(kind: Any, changed_files: Any) -> str:
+    """Resolve the candidate kind, falling back to the legacy changed_files column when kind is absent (None)."""
+    if kind is not None:
+        return str(kind).strip().lower()
+    changed = str(changed_files or "").strip().lower()
+    if changed and changed != "none":
+        return "source_edit"
+    return "argument_only"
+
+
 def load_results(path: Path) -> List[ProgressRecord]:
     records = []
     with path.open("r", encoding="utf-8", newline="") as f:
@@ -124,6 +137,9 @@ def load_results(path: Path) -> List[ProgressRecord]:
                     score=parse_score(row.get("score", "")),
                     runtime_seconds=parse_runtime(row.get("runtime_seconds", "")),
                     description=row.get("diff_summary", "") or row.get("description", ""),
+                    kind=resolve_candidate_kind(row.get("candidate_kind"), row.get("changed_files", "")),
+                    family=(row.get("algorithm_family", "") or "").strip(),
+                    literature_event_id=(row.get("literature_event_id", "") or "").strip(),
                 )
             )
     return records
@@ -132,6 +148,9 @@ def load_results(path: Path) -> List[ProgressRecord]:
 def normalize_records(records: Iterable[Any]) -> List[ProgressRecord]:
     normalized = []
     for index, record in enumerate(records):
+        kind = getattr(record, "candidate_kind", None)
+        if kind is None:
+            kind = getattr(record, "kind", None)
         normalized.append(
             ProgressRecord(
                 index=index,
@@ -140,6 +159,9 @@ def normalize_records(records: Iterable[Any]) -> List[ProgressRecord]:
                 score=parse_score(getattr(record, "score", None)),
                 runtime_seconds=parse_runtime(getattr(record, "runtime_seconds", 0.0)),
                 description=str(getattr(record, "diff_summary", "") or getattr(record, "description", "") or ""),
+                kind=resolve_candidate_kind(kind, getattr(record, "changed_files", "")),
+                family=str(getattr(record, "algorithm_family", "") or getattr(record, "family", "") or "").strip(),
+                literature_event_id=str(getattr(record, "literature_event_id", "") or "").strip(),
             )
         )
     return normalized
@@ -314,20 +336,33 @@ def plot_progress(
         "candidate": [record for record in valid if record.status == "candidate"],
         "keep": [record for record in valid if record.status in {"baseline", "keep"}],
     }
+    literature_edge = "#8e44ad"
     for status, group in groups.items():
         if not group:
             continue
         style = styles[status]
+        base_edge = "black" if status == "keep" else "none"
+        base_width = 0.5 if status == "keep" else 0.0
+        source_edits = [record for record in group if record.kind == "source_edit"]
+        argument_only = [record for record in group if record.kind != "source_edit"]
+        for subgroup, marker, label_suffix in ((argument_only, "o", ""), (source_edits, "D", " (source edit)")):
+            if not subgroup:
+                continue
+            ax.scatter(
+                [record.index for record in subgroup],
+                [record.score for record in subgroup],
+                c=style["color"],
+                s=style["size"],
+                alpha=style["alpha"],
+                marker=marker,
+                zorder=4 if status == "keep" else 2,
+                label=style["label"] + label_suffix,
+                edgecolors=[literature_edge if record.literature_event_id else base_edge for record in subgroup],
+                linewidths=[0.9 if record.literature_event_id else base_width for record in subgroup],
+            )
+    if any(record.literature_event_id for group in groups.values() for record in group):
         ax.scatter(
-            [record.index for record in group],
-            [record.score for record in group],
-            c=style["color"],
-            s=style["size"],
-            alpha=style["alpha"],
-            zorder=4 if status == "keep" else 2,
-            label=style["label"],
-            edgecolors="black" if status == "keep" else "none",
-            linewidths=0.5 if status == "keep" else 0,
+            [], [], facecolors="none", edgecolors=literature_edge, linewidths=0.9, s=40, label="Literature-linked"
         )
 
     known_statuses = {"baseline", "keep", "discard", "candidate", "crash", "literature"}
@@ -431,8 +466,11 @@ def plot_progress(
 
     for label_number, (_, record) in enumerate(select_observed_milestones(valid, mode, max_labels)):
         offset, horizontal_align, vertical_align = label_placement(label_number, record, ax.get_xlim(), ax.get_ylim())
+        milestone_text = f"#{record.index} {record.score:.4f}: {record_label(record, 28)}"
+        if record.literature_event_id:
+            milestone_text += f" [{record.family or record.literature_event_id}]"
         annotation = ax.annotate(
-            f"#{record.index} {record.score:.4f}: {record_label(record, 28)}",
+            milestone_text,
             (record.index, record.score),
             textcoords="offset points",
             xytext=offset,

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -69,6 +69,9 @@ RESULT_FIELDS = [
     "metric_name",
     "metric_source",
     "metric_artifact",
+    "candidate_kind",
+    "algorithm_family",
+    "literature_event_id",
 ]
 
 CANDIDATE_MANIFEST_SCHEMA_VERSION = "nvflare.autofl.candidate.v1"
@@ -145,6 +148,9 @@ class RunRecord:
     metric_name: str = ""
     metric_source: str = ""
     metric_artifact: str = ""
+    candidate_kind: str = ""
+    algorithm_family: str = ""
+    literature_event_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -231,6 +237,24 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="stop after this many consecutive real candidate crashes; set 0 to disable",
     )
     parser.add_argument(
+        "--exploration-batch-size",
+        type=int,
+        default=env_int("AUTOFL_EXPLORATION_BATCH_SIZE", guard.DEFAULT_EXPLORATION_BATCH_SIZE),
+        help=(
+            "scored source-backed candidates required per literature event before normal candidate "
+            "flow resumes; set 0 to disable"
+        ),
+    )
+    parser.add_argument(
+        "--family-repeat-limit",
+        type=int,
+        default=env_int("AUTOFL_FAMILY_REPEAT_LIMIT", guard.DEFAULT_FAMILY_REPEAT_LIMIT),
+        help=(
+            "consecutive same-family argument-only scored attempts before campaign state requires "
+            "diversification; set 0 to disable"
+        ),
+    )
+    parser.add_argument(
         "--stop-file",
         action="append",
         help="manual stop-file path; defaults to STOP_AUTOFL and .nvflare/autofl/STOP under the job directory",
@@ -252,6 +276,8 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--synthetic-test-size", type=int, default=256)
     parser.add_argument("--name", help="candidate name for prepare")
     parser.add_argument("--hypothesis", help="candidate hypothesis for prepare")
+    parser.add_argument("--family", help="algorithm family slug for prepare or record --literature")
+    parser.add_argument("--literature-event", help="literature event id this candidate develops (prepare)")
     parser.add_argument("--manifest", help="candidate_manifest.json path")
     parser.add_argument("--run-args", default="", help="candidate-only job.py arguments")
     parser.add_argument("--score", type=float, help="externally measured metric for record")
@@ -1768,6 +1794,9 @@ def write_results(path: Path, records: List[RunRecord]) -> None:
                 "metric_name": record.metric_name,
                 "metric_source": record.metric_source,
                 "metric_artifact": record.metric_artifact,
+                "candidate_kind": record.candidate_kind,
+                "algorithm_family": record.algorithm_family,
+                "literature_event_id": record.literature_event_id,
             }
         )
     atomic_write_bytes(path, stream.getvalue().encode("utf-8"))
@@ -1797,6 +1826,9 @@ def load_results(path: Path) -> List[RunRecord]:
                     metric_name=row.get("metric_name", ""),
                     metric_source=row.get("metric_source", ""),
                     metric_artifact=row.get("metric_artifact", ""),
+                    candidate_kind=row.get("candidate_kind", "") or "",
+                    algorithm_family=row.get("algorithm_family", "") or "",
+                    literature_event_id=row.get("literature_event_id", "") or "",
                 )
             )
     return records
@@ -1817,6 +1849,8 @@ def write_state(
     plateau_threshold: Optional[int] = None,
     plateau_min_delta: Optional[float] = None,
     hard_crash_threshold: Optional[int] = None,
+    exploration_batch_size: Optional[int] = None,
+    family_repeat_limit: Optional[int] = None,
     pending_manifest_count: int = 0,
     persist: bool = True,
 ) -> Dict[str, Any]:
@@ -1824,6 +1858,10 @@ def write_state(
     plateau_threshold = guard.DEFAULT_PLATEAU_THRESHOLD if plateau_threshold is None else plateau_threshold
     plateau_min_delta = guard.DEFAULT_MIN_DELTA if plateau_min_delta is None else plateau_min_delta
     hard_crash_threshold = guard.DEFAULT_HARD_CRASH_THRESHOLD if hard_crash_threshold is None else hard_crash_threshold
+    exploration_batch_size = (
+        guard.DEFAULT_EXPLORATION_BATCH_SIZE if exploration_batch_size is None else exploration_batch_size
+    )
+    family_repeat_limit = guard.DEFAULT_FAMILY_REPEAT_LIMIT if family_repeat_limit is None else family_repeat_limit
     state = guard.guard_state(
         results_path,
         max_candidates=max_candidates,
@@ -1833,6 +1871,8 @@ def write_state(
         hard_crash_threshold=hard_crash_threshold,
         mode=mode,
         pending_manifest_count=pending_manifest_count,
+        exploration_batch_size=exploration_batch_size,
+        family_repeat_limit=family_repeat_limit,
     )
     if records and records[-1].status == INFRASTRUCTURE_RETRY:
         attempts = len(
@@ -2062,6 +2102,8 @@ CAMPAIGN_SETTING_NAMES = (
     "plateau_threshold",
     "plateau_min_delta",
     "hard_crash_threshold",
+    "exploration_batch_size",
+    "family_repeat_limit",
     "stop_file",
     "base_args",
     "timeout",
@@ -2077,6 +2119,8 @@ MUTABLE_CAMPAIGN_SETTING_NAMES = {
     "plateau_threshold",
     "plateau_min_delta",
     "hard_crash_threshold",
+    "exploration_batch_size",
+    "family_repeat_limit",
     "stop_file",
     "timeout",
     "simulator_no_progress_timeout",
@@ -2220,7 +2264,6 @@ def refresh_campaign_artifacts(
     pending_manifest: Optional[Path] = None,
     next_action: Optional[str] = None,
     reason: Optional[str] = None,
-    required_exploration: Optional[str] = None,
 ) -> Dict[str, Any]:
     pending_manifests = pending_candidate_manifests(paths["workspace"])
     if pending_manifest is not None and pending_manifest not in pending_manifests:
@@ -2236,6 +2279,8 @@ def refresh_campaign_artifacts(
         plateau_threshold=args.plateau_threshold,
         plateau_min_delta=args.plateau_min_delta,
         hard_crash_threshold=args.hard_crash_threshold,
+        exploration_batch_size=args.exploration_batch_size,
+        family_repeat_limit=args.family_repeat_limit,
         pending_manifest_count=len(pending_manifests),
     )
     if state.get("next_action") == "abandon_candidate":
@@ -2249,12 +2294,6 @@ def refresh_campaign_artifacts(
         state["next_action"] = next_action
         state["reason"] = reason or next_action
         state["agent_instruction"] = f"Do not produce a final answer. Execute `{next_action}` for this campaign."
-    if required_exploration:
-        state["required_exploration"] = required_exploration
-        state["agent_instruction"] = (
-            f"{state['agent_instruction']} Prepare and evaluate at least one source-backed server aggregation "
-            "candidate when compatible with the job contract; otherwise record why it is incompatible."
-        )
     state.update(
         {
             "best_candidate": metadata.get("best_candidate"),
@@ -2432,6 +2471,12 @@ def prepare_candidate(args: argparse.Namespace, job: Path) -> int:
     candidate_id = validate_candidate_id(args.name or "")
     if not args.hypothesis:
         raise ValueError("--hypothesis is required for prepare")
+    algorithm_family = (args.family or "").strip().lower()
+    literature_event = (args.literature_event or "").strip()
+    if literature_event:
+        known_events = {record.literature_event_id for record in records if record.status == "literature"}
+        if literature_event not in known_events:
+            raise ValueError(f"unknown literature event id: {literature_event}")
     manifest_path = candidate_manifest_path(workspace, candidate_id)
     candidate_dir = manifest_path.parent
     if candidate_dir.exists():
@@ -2450,6 +2495,8 @@ def prepare_candidate(args: argparse.Namespace, job: Path) -> int:
         "candidate_id": candidate_id,
         "name": candidate_id,
         "hypothesis": args.hypothesis,
+        "algorithm_family": algorithm_family,
+        "literature_event_id": literature_event,
         "status": "prepared",
         "created_at": utc_now(),
         "updated_at": utc_now(),
@@ -2529,6 +2576,8 @@ def validate_candidate_for_evaluation(
         raise ValueError(reason)
     if not changed and not run_args:
         raise ValueError("candidate has no source changes or run arguments")
+    if (str(manifest.get("literature_event_id") or "")).strip() and not changed and not created:
+        raise ValueError("literature-linked candidates must include source edits")
     patch = render_candidate_patch(best_source, draft_source, changed)
     return manifest, config, best_source, best_files, changed, created, patch
 
@@ -2601,6 +2650,9 @@ def finalize_candidate_result(
         record.candidate_manifest = str(manifest_path.resolve())
         record.base_candidate = str(manifest.get("base_candidate") or "")
         record.patch_sha256 = patch_sha256
+        record.candidate_kind = "source_edit" if changed or created else "argument_only"
+        record.algorithm_family = str(manifest.get("algorithm_family") or "")
+        record.literature_event_id = str(manifest.get("literature_event_id") or "")
 
         if record.status == "keep":
             update_config_for_kept_sources(config, created)
@@ -2625,6 +2677,7 @@ def finalize_candidate_result(
                 "updated_at": utc_now(),
                 "changed_files": changed,
                 "created_files": created,
+                "candidate_kind": record.candidate_kind,
                 "patch_sha256": patch_sha256,
                 "artifacts": {"patch": str(patch_path.resolve()), "run": record.artifacts},
                 "result": {
@@ -2888,7 +2941,9 @@ def record_external_result(args: argparse.Namespace, job: Path) -> int:
         )
     if args.literature:
         records = load_results(paths["results"])
-        name = f"literature_review_{sum(record.status == 'literature' for record in records) + 1}"
+        event_number = sum(record.status == "literature" for record in records) + 1
+        event_id = f"lit-{event_number:04d}"
+        name = f"literature_review_{event_number}"
         records.append(
             RunRecord(
                 status="literature",
@@ -2899,19 +2954,14 @@ def record_external_result(args: argparse.Namespace, job: Path) -> int:
                 diff_summary=args.hypothesis or "source-backed literature review",
                 run_command="agent literature review",
                 artifacts=str(artifact_path or ""),
+                algorithm_family=(args.family or "").strip().lower(),
+                literature_event_id=event_id,
             )
         )
-        state = refresh_campaign_artifacts(
-            args,
-            paths,
-            config,
-            records,
-            metadata,
-            next_action="propose_candidate",
-            reason="literature_review_recorded",
-            required_exploration="source_backed_server_aggregation",
-        )
-        print_campaign_result(paths, records, state, literature_event=name)
+        # The guard now derives next_action=develop_literature_batch and keeps
+        # required_exploration active until the linked exploration batch completes.
+        state = refresh_campaign_artifacts(args, paths, config, records, metadata)
+        print_campaign_result(paths, records, state, literature_event=name, literature_event_id=event_id)
         return 0
     if args.baseline:
         records = load_results(paths["results"])

--- a/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
+++ b/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
@@ -32,6 +32,9 @@ RESULT_FIELDS = [
     "candidate_manifest",
     "base_candidate",
     "patch_sha256",
+    "candidate_kind",
+    "algorithm_family",
+    "literature_event_id",
 ]
 
 
@@ -53,13 +56,23 @@ def _write_results(path, rows):
             writer.writerow(row)
 
 
-def _row(status, name, score="", diff_summary="candidate", run_command="python job.py"):
+def _row(
+    status,
+    name,
+    score="",
+    diff_summary="candidate",
+    run_command="python job.py",
+    changed_files="none",
+    kind="",
+    family="",
+    lit="",
+):
     return {
         "status": status,
         "name": name,
         "score": score,
         "runtime_seconds": "10.0",
-        "changed_files": "none",
+        "changed_files": changed_files,
         "diff_summary": diff_summary,
         "run_command": run_command,
         "artifacts": "/tmp/run",
@@ -67,6 +80,9 @@ def _row(status, name, score="", diff_summary="candidate", run_command="python j
         "candidate_manifest": "",
         "base_candidate": "",
         "patch_sha256": "",
+        "candidate_kind": kind,
+        "algorithm_family": family,
+        "literature_event_id": lit,
     }
 
 
@@ -102,24 +118,89 @@ def test_guard_routes_plateau_to_literature_without_finalizing():
     assert state["next_action"] == "run_literature_loop"
     assert state["final_response_allowed"] is False
     assert state["best_score"] == 0.85
-    assert state["required_exploration"] == "source_backed_server_aggregation"
-    assert "server aggregation candidate" in state["agent_instruction"]
+    assert state["required_exploration"] == "source_backed_exploration"
+    assert "--literature-event" in state["agent_instruction"]
     assert "Do not produce a final answer" in state["agent_instruction"]
 
 
-def test_guard_literature_event_resets_plateau_clock():
+def test_guard_literature_recording_alone_does_not_reset_plateau_clock():
     guard = _load_guard()
     rows = [_row("baseline", "baseline", "0.85")]
     rows.extend(_row("discard", f"before_lit_{idx}", "0.840") for idx in range(4))
-    rows.append(_row("literature", "literature_review", "", diff_summary="literature review"))
-    rows.extend(_row("discard", f"after_lit_{idx}", "0.841") for idx in range(2))
+    rows.append(_row("literature", "literature_review_1", "", diff_summary="literature review", lit="lit-0001"))
+    rows.extend(_row("discard", f"after_lit_{idx}", "0.841", kind="argument_only") for idx in range(2))
 
+    state = guard.guard_state_for_rows(rows, plateau_threshold=4)
+
+    # The batch is incomplete, so campaign state demands source-backed development
+    # and the plateau clock keeps counting from the last real improvement.
+    assert state["reason"] == "literature_exploration_batch"
+    assert state["next_action"] == "develop_literature_batch"
+    assert state["required_exploration"] == "source_backed_exploration"
+    assert state["exploration_batch"]["literature_event_id"] == "lit-0001"
+    assert state["exploration_batch"]["completed"] == 0
+    assert state["plateau"]["last_literature_event_index"] == 5
+    assert state["plateau"]["scored_since_reset"] == 6
+
+
+def test_guard_exploration_batch_completion_resets_plateau_and_resumes_flow():
+    guard = _load_guard()
+    rows = [_row("baseline", "baseline", "0.85")]
+    rows.extend(_row("discard", f"before_lit_{idx}", "0.840") for idx in range(4))
+    rows.append(_row("literature", "literature_review_1", "", diff_summary="literature review", lit="lit-0001"))
+    rows.append(_row("discard", "faithful", "0.842", kind="source_edit", family="fedyogi", lit="lit-0001"))
+    rows.append(_row("discard", "arg_only_linked", "0.83", kind="argument_only", family="fedyogi", lit="lit-0001"))
+    rows.append(_row("discard", "tuned", "0.845", kind="source_edit", family="fedyogi", lit="lit-0001"))
+
+    state = guard.guard_state_for_rows(rows, plateau_threshold=4)
+
+    # Argument-only rows never count toward the source-backed batch.
+    assert state["next_action"] == "develop_literature_batch"
+    assert state["exploration_batch"]["completed"] == 2
+
+    rows.append(_row("discard", "ablation", "0.841", kind="source_edit", family="fedyogi", lit="lit-0001"))
     state = guard.guard_state_for_rows(rows, plateau_threshold=4)
 
     assert state["reason"] == "continue"
     assert state["next_action"] == "propose_candidate"
-    assert state["plateau"]["last_literature_event_index"] == 5
-    assert state["plateau"]["scored_since_reset"] == 2
+    assert state["required_exploration"] is None
+    assert state["exploration_batch"]["completed"] == 3
+    assert state["plateau"]["last_batch_completion_index"] == len(rows) - 1
+    assert state["plateau"]["scored_since_reset"] == 0
+
+
+def test_guard_family_repeat_limiter_requires_diversification():
+    guard = _load_guard()
+    rows = [_row("baseline", "baseline", "0.85")]
+    rows.append(_row("literature", "literature_review_1", "", diff_summary="literature review", lit="lit-0001"))
+    rows.extend(
+        _row("discard", f"lit_{idx}", "0.84", kind="source_edit", family="fedyogi", lit="lit-0001") for idx in range(3)
+    )
+    rows.extend(_row("discard", f"tune_{idx}", "0.845", kind="argument_only", family="fedavgm") for idx in range(6))
+
+    state = guard.guard_state_for_rows(rows, plateau_threshold=20)
+
+    assert state["reason"] == "family_repeat_limit"
+    assert state["next_action"] == "diversify_candidates"
+    assert "source-backed candidate" in state["agent_instruction"]
+
+
+def test_guard_legacy_rows_use_changed_files_fallback_and_zero_batch_disables_gate():
+    guard = _load_guard()
+    rows = [_row("baseline", "baseline", "0.85")]
+    rows.append(_row("literature", "literature_review_1", "", diff_summary="literature review"))
+    rows.append(_row("discard", "legacy_source", "0.84", changed_files="client.py"))
+    rows.append(_row("discard", "legacy_args", "0.84"))
+
+    state = guard.guard_state_for_rows(rows, plateau_threshold=20)
+    # Legacy rows without candidate_kind derive it from changed_files; unlinked
+    # source rows after the latest event count toward its batch.
+    assert state["next_action"] == "develop_literature_batch"
+    assert state["exploration_batch"]["completed"] == 1
+
+    state = guard.guard_state_for_rows(rows, plateau_threshold=20, exploration_batch_size=0)
+    assert state["next_action"] == "propose_candidate"
+    assert state["required_exploration"] is None
 
 
 def test_guard_counts_candidate_with_baseline_in_description():
@@ -273,6 +354,8 @@ def test_continuous_campaign_reference_documents_only_emitted_actions():
         "submit_candidate",
         "rerun_with_escalated_execution",
         "run_literature_loop",
+        "develop_literature_batch",
+        "diversify_candidates",
         "final_report",
     }
 

--- a/tests/unit_test/tool/autofl_skill_plot_progress_test.py
+++ b/tests/unit_test/tool/autofl_skill_plot_progress_test.py
@@ -16,6 +16,7 @@ import csv
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -30,7 +31,7 @@ def _load_plotter():
     return module
 
 
-def _record(plotter, index, score, status="discard", name=None, runtime=300.0):
+def _record(plotter, index, score, status="discard", name=None, runtime=300.0, kind="", family="", lit_id=""):
     return plotter.ProgressRecord(
         index=index,
         status=status,
@@ -38,6 +39,9 @@ def _record(plotter, index, score, status="discard", name=None, runtime=300.0):
         score=score,
         runtime_seconds=runtime,
         description=f"candidate {index}",
+        kind=kind,
+        family=family,
+        literature_event_id=lit_id,
     )
 
 
@@ -105,8 +109,98 @@ def test_load_results_uses_productized_ledger_fields(tmp_path):
 
     records = plotter.load_results(ledger)
 
-    assert records == [plotter.ProgressRecord(0, "keep", "fedavgm", 0.75, 123.5, "server momentum")]
+    # Legacy ledger has no candidate_kind/changed_files columns, so kind falls back to "argument_only".
+    assert records == [plotter.ProgressRecord(0, "keep", "fedavgm", 0.75, 123.5, "server momentum", "argument_only")]
     assert plotter.normalize_records(records) == records
+
+
+def test_load_results_populates_candidate_kind_family_and_literature_link(tmp_path):
+    plotter = _load_plotter()
+    ledger = tmp_path / "results.tsv"
+    fieldnames = [
+        "status",
+        "name",
+        "score",
+        "runtime_seconds",
+        "diff_summary",
+        "changed_files",
+        "candidate_kind",
+        "algorithm_family",
+        "literature_event_id",
+    ]
+    with ledger.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerow({"status": "baseline", "name": "baseline", "score": "0.687", "runtime_seconds": "100"})
+        writer.writerow(
+            {
+                "status": "keep",
+                "name": "fedprox_mu",
+                "score": "0.75",
+                "runtime_seconds": "120",
+                "changed_files": "client.py",
+                "candidate_kind": "source_edit",
+                "algorithm_family": "fedprox",
+                "literature_event_id": "lit-0001",
+            }
+        )
+        writer.writerow(
+            {
+                "status": "discard",
+                "name": "higher_lr",
+                "score": "0.70",
+                "runtime_seconds": "110",
+                "candidate_kind": "argument_only",
+            }
+        )
+
+    records = plotter.load_results(ledger)
+
+    assert [record.kind for record in records] == ["", "source_edit", "argument_only"]
+    assert [record.family for record in records] == ["", "fedprox", ""]
+    assert [record.literature_event_id for record in records] == ["", "lit-0001", ""]
+
+
+def test_normalize_records_reads_run_record_attributes_with_changed_files_fallback():
+    plotter = _load_plotter()
+    runs = [
+        SimpleNamespace(
+            status="keep",
+            name="scaffold_variant",
+            score=0.76,
+            runtime_seconds=100.0,
+            diff_summary="control variates",
+            changed_files="client.py",
+            candidate_kind="source_edit",
+            algorithm_family="scaffold",
+            literature_event_id="lit-0002",
+        ),
+        # Legacy run records without the new columns fall back to changed_files.
+        SimpleNamespace(
+            status="discard",
+            name="legacy_edit",
+            score=0.70,
+            runtime_seconds=90.0,
+            diff_summary="edited trainer",
+            changed_files="trainer.py",
+        ),
+        SimpleNamespace(
+            status="discard",
+            name="legacy_args",
+            score=0.69,
+            runtime_seconds=80.0,
+            diff_summary="tuned lr",
+            changed_files="none",
+        ),
+    ]
+
+    records = plotter.normalize_records(runs)
+
+    assert [record.kind for record in records] == ["source_edit", "source_edit", "argument_only"]
+    assert records[0].family == "scaffold"
+    assert records[0].literature_event_id == "lit-0002"
+    assert [record.family for record in records[1:]] == ["", ""]
+    assert [record.literature_event_id for record in records[1:]] == ["", ""]
 
 
 def test_zero_score_label_uses_the_actual_score():
@@ -133,5 +227,26 @@ def test_rich_progress_plot_renders_png(tmp_path):
 
     assert baseline == pytest.approx(0.687)
     assert best == pytest.approx(0.73)
+    assert output.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    assert output.stat().st_size > 20_000
+
+
+def test_progress_plot_distinguishes_candidate_kinds(tmp_path):
+    pytest.importorskip("matplotlib")
+    plotter = _load_plotter()
+    records = [
+        _record(plotter, 0, 0.687, status="baseline", name="baseline"),
+        _record(plotter, 1, None, status="literature", name="lit_review", runtime=45.0, lit_id="lit-0001"),
+        _record(plotter, 2, 0.70, status="discard", kind="argument_only"),
+        _record(plotter, 3, 0.71, status="discard", kind="source_edit"),
+        _record(plotter, 4, 0.72, status="candidate", kind="argument_only"),
+        _record(plotter, 5, 0.75, status="keep", kind="source_edit", family="fedprox", lit_id="lit-0001"),
+    ]
+    output = tmp_path / "progress.png"
+
+    baseline, best = plotter.plot_progress(records, output, mode="max", metric_label="test_accuracy")
+
+    assert baseline == pytest.approx(0.687)
+    assert best == pytest.approx(0.75)
     assert output.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
     assert output.stat().st_size > 20_000

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -1316,10 +1316,97 @@ def test_record_literature_checkpoint_returns_to_agent_proposal(tmp_path, monkey
     records = runner.load_results(tmp_path / "results.tsv")
     assert records[-1].status == "literature"
     assert records[-1].diff_summary == "reviewed adaptive federated optimization"
+    assert records[-1].literature_event_id == "lit-0001"
     state = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_text(encoding="utf-8"))
-    assert state["next_action"] == "propose_candidate"
-    assert state["required_exploration"] == "source_backed_server_aggregation"
-    assert "server aggregation candidate" in state["agent_instruction"]
+    assert state["next_action"] == "develop_literature_batch"
+    assert state["required_exploration"] == "source_backed_exploration"
+    assert state["exploration_batch"]["literature_event_id"] == "lit-0001"
+    assert state["exploration_batch"]["completed"] == 0
+    assert "--literature-event" in state["agent_instruction"]
+
+
+def test_results_roundtrip_preserves_candidate_provenance(tmp_path):
+    runner = _load_runner()
+    records = [
+        runner.RunRecord("baseline", "baseline", 0.5, 1.0, "none", "baseline", "python job.py", "/tmp/baseline"),
+        runner.RunRecord(
+            "keep",
+            "fedyogi_faithful",
+            0.6,
+            1.0,
+            "client.py",
+            "faithful FedYogi implementation",
+            "python job.py",
+            "/tmp/run",
+            candidate_kind="source_edit",
+            algorithm_family="fedyogi",
+            literature_event_id="lit-0001",
+        ),
+    ]
+    results_path = tmp_path / "results.tsv"
+
+    runner.write_results(results_path, records)
+    loaded = runner.load_results(results_path)
+
+    assert loaded[-1].candidate_kind == "source_edit"
+    assert loaded[-1].algorithm_family == "fedyogi"
+    assert loaded[-1].literature_event_id == "lit-0001"
+    assert loaded[0].candidate_kind == ""
+
+
+def test_prepare_rejects_unknown_literature_event(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+
+    rc = runner.main(
+        [
+            "prepare",
+            str(job),
+            "--name",
+            "fedyogi_faithful",
+            "--hypothesis",
+            "faithful FedYogi",
+            "--family",
+            "fedyogi",
+            "--literature-event",
+            "lit-9999",
+        ]
+    )
+
+    assert rc == 2
+    assert "unknown literature event id" in capsys.readouterr().err
+
+
+def test_prepare_persists_family_and_literature_event_in_manifest(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+    assert runner.main(["record", str(job), "--literature", "--hypothesis", "reviewed FedYogi"]) == 0
+
+    assert (
+        runner.main(
+            [
+                "prepare",
+                str(job),
+                "--name",
+                "fedyogi_faithful",
+                "--hypothesis",
+                "faithful FedYogi",
+                "--family",
+                "FedYogi",
+                "--literature-event",
+                "lit-0001",
+            ]
+        )
+        == 0
+    )
+
+    manifest = json.loads(
+        tmp_path.joinpath(".nvflare/autofl/candidates/fedyogi_faithful/candidate_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["algorithm_family"] == "fedyogi"
+    assert manifest["literature_event_id"] == "lit-0001"
 
 
 def test_external_baseline_may_follow_literature_event(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the minimal-compliance failure mode found in a 100-candidate campaign evaluation of the Auto-FL skill (NVIDIA/NVFlare#4780): the agent implemented exactly one custom aggregation candidate per literature review, then returned to FedAvgM argument micro-tuning for 7–11 attempts — 88/100 candidates were argument-only, and promising ideas (trust-scaled FedYogi at 75.84% vs. the 76.29% champion) were never developed into tuned families.

Root causes, all in the old contract: recording a literature row immediately reset the plateau counter; `required_exploration` was a one-shot instruction, not a validated contract; nothing linked candidates to the review they were meant to develop.

## What changed

**Exploration is now a deterministically enforced runner contract:**

- **Provenance** — literature reviews get persistent `literature_event_id` values (`lit-0001`); `prepare` accepts `--family <slug>` and `--literature-event <id>`, persisted in `candidate_manifest.json` and as `candidate_kind` / `algorithm_family` / `literature_event_id` columns in `results.tsv`. A literature-linked candidate **must** contain source edits — the runner rejects argument-only linked candidates at evaluate time.
- **Batch gating** — the guard keeps `next_action=develop_literature_batch` and `required_exploration=source_backed_exploration` until `exploration_batch_size` (default 3, `--exploration-batch-size` / `AUTOFL_EXPLORATION_BATCH_SIZE`, 0 disables) scored source-backed candidates linked to the latest review exist. Recommended composition (agent guidance): faithful implementation, tuned variant, ablation.
- **Plateau semantics** — the plateau clock resets when the exploration batch *completes*, not when the review is recorded. Recording a review no longer relieves plateau pressure.
- **Family repeat limiter** — after the first review, `family_repeat_limit` (default 6, `--family-repeat-limit` / `AUTOFL_FAMILY_REPEAT_LIMIT`) consecutive same-family argument-only scored attempts trigger `next_action=diversify_candidates`.
- **Workload-aware selection** — the exploration requirement is no longer server-aggregation-only (client optimizer, loss, schedule, architecture qualify); SKILL.md instructs threat-model matching (no Byzantine-robust aggregation for benign-client campaigns).
- **Visibility** — `progress.png` renders source-edited candidates as distinct markers and annotates literature-linked families, so token compliance is visible at a glance.

Legacy ledgers remain readable: missing columns fall back to deriving kind from `changed_files`, and unlinked event rows get positional IDs.

## Enforceable vs. instructional boundary

The runner enforces what it can verify deterministically (count, linkage, source-edit requirement, plateau accounting, family repetition); role semantics ("faithful", "ablation") and threat-model matching stay agent guidance in SKILL.md — consistent with the skill's design philosophy that NVFlare owns the verifiable contract and the agent owns judgment.

## Validation

- 125 Auto-FL unit tests pass (guard, runner, importer, plot), including new tests for batch gating, plateau-reset-on-completion, the family limiter, legacy fallbacks, manifest persistence, and unknown-event rejection.
- 38 skill packaging / frontmatter tests pass.
- black, isort, flake8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)