### PR TITLE
Keep SKILL.md within the 200-line admission limit

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -14,46 +14,39 @@ metadata:
 # NVFLARE Auto-FL
 
 ## Use When
-Use this skill when the user asks to optimize an existing NVFLARE `job.py` for
-accuracy, AUC, loss, runtime, robustness, or another metric in simulation, POC,
-or production.
+Use this skill when the user asks to optimize an existing NVFLARE `job.py` for accuracy,
+AUC, loss, runtime, robustness, or another metric in simulation, POC, or production.
 
 ## Do Not Use When
-Do not use for converting non-FL training code into NVFLARE, diagnosing failed
-jobs without an optimization goal, production deployment setup, or generic
-hyperparameter tuning outside an NVFLARE job.
+Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs
+without an optimization goal, production deployment setup, or generic hyperparameter
+tuning outside an NVFLARE job.
 
 ## Workflow
-Use this skill to optimize an existing NVFLARE `job.py` without asking the user
-to learn a new Auto-FL command tree. The user selects this skill, points to a
-job, and states the objective, environment, and optional budget. NVFLARE
-provides the deterministic campaign import, execution substrate, policy
-boundaries, artifacts, and machine-readable contracts. The coding agent owns
-hypotheses, source edits, new algorithm implementations, and candidate choice.
+Use this skill to optimize an existing NVFLARE `job.py` without asking the user to learn
+a new Auto-FL command tree. The user selects this skill, points to a job, and states the
+objective, environment, and optional budget. NVFLARE provides the deterministic campaign
+import, execution substrate, policy boundaries, artifacts, and machine-readable
+contracts. The coding agent owns hypotheses, source edits, new algorithm
+implementations, and candidate choice.
 
-Resolve [run_job_campaign.py](scripts/run_job_campaign.py) relative to this
-`SKILL.md`, store its absolute path as `RUNNER`, and initialize the campaign:
+Resolve [run_job_campaign.py](scripts/run_job_campaign.py) relative to this `SKILL.md`, store its absolute path as `RUNNER`, and initialize the campaign:
 
 ```bash
 python "$RUNNER" initialize ./job.py [--metric <metric>] --mode <max|min> --env <sim|poc|prod> [--max-candidates <n>]
 ```
 
-Read `autofl.yaml` and the JSON response, then prepare an agent-authored
-candidate with a short hypothesis and optional candidate-only arguments:
+Read `autofl.yaml` and the JSON response, then prepare an agent-authored candidate with a short hypothesis and optional candidate-only arguments:
 
 ```bash
 python "$RUNNER" prepare ./job.py --name <candidate> --hypothesis "<expected improvement>" [--run-args "<args>"] [--family <slug>] [--literature-event <id>]
 ```
 
-Pass `--family` with an algorithm-family slug (for example `fedyogi` or
-`adaptive-clipping`) and `--literature-event` with the review's
-`literature_event_id` when the candidate implements a literature idea. Both are
-persisted in `candidate_manifest.json` and as the `candidate_kind`,
-`algorithm_family`, and `literature_event_id` columns in `results.tsv`.
+Pass `--family <slug>` and `--literature-event <id>` when the candidate develops a
+recorded literature review; both persist in the manifest and as ledger columns.
 
-Edit only the returned candidate source directory. Modify existing allowed
-files or add Python modules under the job root; do not edit the live best source
-directly. Then evaluate the manifest:
+Edit only the returned candidate source directory. Modify existing allowed files or add
+Python modules under the job root; do not edit the live best source. Then evaluate:
 
 ```bash
 python "$RUNNER" evaluate ./job.py --manifest <candidate_manifest.json>
@@ -62,34 +55,31 @@ python "$RUNNER" evaluate ./job.py --manifest <candidate_manifest.json>
 Simulation evaluation runs the candidate immediately. POC and production
 evaluation validates and materializes the candidate; submit it with standard
 `nvflare job` commands, then call `record` with the manifest, job ID, artifacts,
-and score. Use `abandon` to restore a pending candidate. Use `suggest` only when
-you want deterministic tunable seeds; suggestions are never executed
-automatically and do not limit agent-authored code candidates.
+and score. Use `abandon` to restore a pending candidate. Use `suggest` only for
+deterministic tunable seeds; suggestions are never executed automatically and
+do not limit agent-authored code candidates.
 
 If the job directory contains a task-local `mutation_schema.yaml`, treat its
 `comparison_budget_args.default_candidate_budget` and mutation bounds as
 authoritative. Invalid generated proposals are product friction, not campaign
-blockers; preserve the same campaign and continue with another same-budget
-candidate.
+blockers; keep the same campaign and continue with another same-budget candidate.
 
 Treat `job.py`, generated `autofl.yaml`, and optional job-local
-`mutation_schema.yaml` as campaign inputs. Do not require example-specific
-runbooks, branches, or initialization scripts.
+`mutation_schema.yaml` as the campaign inputs — no example-specific runbooks,
+branches, or initialization scripts.
 
 Request escalated execution for the runner command because NVFLARE simulator
-runs create local sockets that fail inside the restricted Codex sandbox. If a
-runner command reports a sandbox/socket permission failure, treat it as an
-infrastructure retry, not as a candidate result, and rerun the same command with
-escalated execution.
+runs create local sockets that fail inside the restricted Codex sandbox. Treat
+a reported sandbox/socket permission failure as an infrastructure retry, not a
+candidate result, and rerun the same command with escalated execution.
 
 The helper owns deterministic import, source snapshots, candidate validation,
 execution, restoration, counting, ledger updates, campaign state, plotting,
 and reports. After each lifecycle action, read
 `.nvflare/autofl/campaign_state.json` and only finalize when
-`final_response_allowed=true`. For long-running and simulator-stall handling, read
-[continuous-campaigns.md](references/continuous-campaigns.md).
-For comparison budgets, data distributions, and rerun evidence, read
-[experiment comparability](references/experiment-comparability.md).
+`final_response_allowed=true`. For long-running and stall handling read
+[continuous-campaigns.md](references/continuous-campaigns.md); for comparison
+budgets and rerun evidence, [experiment comparability](references/experiment-comparability.md).
 
 Read `autofl.yaml` and show the user a concise campaign summary:
 
@@ -101,18 +91,17 @@ Read `autofl.yaml` and show the user a concise campaign summary:
   fixed-budget fields it must preserve, and policy boundaries for the requested
   environment.
 
-Treat `autofl.yaml` as the human-reviewable Auto-FL campaign config, not as a
-replacement for `job.py` or an exported NVFLARE job folder. Use the original
-`job.py` as the runnable experiment entry point throughout the candidate loop.
-
-If `autofl.yaml` contains unresolved fields that affect execution safety,
-candidate comparability, or production submission, ask the user to resolve those
-specific fields before running candidates.
+Treat `autofl.yaml` as the human-reviewable campaign config, not a replacement
+for `job.py`, which stays the runnable entry point throughout the candidate
+loop. Ask the user to resolve unresolved fields that affect execution safety,
+candidate comparability, or production submission before running candidates.
 
 ## Requirements
 - Edit existing files only through candidate drafts and within
-  `trust_contract.allowed_edit_paths`. New Python modules may match
+  `trust_contract.allowed_edit_paths`; new Python modules may match
   `trust_contract.allowed_create_patterns` under the job root.
+- Record every candidate in a ledger such as `results.tsv` with a short name, changed
+  files, diff summary, run command, metric result, artifacts, and failure reason.
 - Use existing `mutation_schema.yaml` `preferred_targets` only after the runner
   reflects them in the trust contract; surface unresolved targets.
 - You may create and register new Python server aggregators through `job.py`;
@@ -120,33 +109,28 @@ specific fields before running candidates.
 - Preserve `budget.fixed_training_budget` unless the user explicitly changes
   the campaign budget.
 - If the environment provides `PYTHON`, `VIRTUAL_ENV`, or a venv on `PATH`,
-  treat that prepared runtime as authoritative. Verify it, then use it for
+  treat that prepared runtime as authoritative: verify it, then use it for
   import, validation, execution, metric extraction, plotting, and reporting.
   Do not search for alternate interpreters or install dependencies unless the
   user explicitly asks you to prepare the environment.
 - Treat generated `autofl.yaml`, task-local `mutation_schema.yaml`, and
-  existing NVFLARE job/runtime configuration as authoritative. In the default
-  simulation product flow, do not require task-local prose profiles, special
-  branch setup, or harness initialization before invoking the runner.
+  existing NVFLARE job/runtime configuration as authoritative; the default
+  simulation flow needs no prose profiles, branch setup, or harness
+  initialization before invoking the runner.
 - Use NVFLARE's existing execution surfaces:
   - For simulation, run the imported job with its configured `SimEnv`.
   - For POC and production, use standard `nvflare job submit`, `job wait`,
     `job download`, and related job/status commands.
-- Record every candidate in a ledger such as `results.tsv` with a short name,
-  changed files, diff summary, run command, metric result, artifacts, and
-  failure reason when applicable.
 - Prefer small, reviewable edits over broad rewrites.
 - Treat production as an available execution environment, but never bypass
   startup-kit authentication, site policy, or normal NVFLARE job submission.
 
 ## Candidate Loop
 1. Inspect `autofl.yaml`, current best source, prior manifests, and results.
-2. Form a concrete hypothesis. Use literature, framework knowledge, source
-   edits, new client or server algorithms, or a fallback tunable suggestion as
-   appropriate.
+2. Form a concrete hypothesis from literature, framework knowledge, source edits, new
+   client or server algorithms, or a fallback tunable suggestion.
 3. Prepare a candidate, edit its draft, and evaluate its manifest.
-4. Let the helper validate paths and fixed-budget comparability, compute the
-   patch hash, execute or materialize it, extract metrics, and keep or restore.
+4. Let the helper validate paths and fixed-budget comparability, compute the patch hash, execute or materialize it, extract metrics, and keep or restore.
 5. Read campaign state and execute `next_action`. When it requests a literature
    pass, run it, record it, then complete the full source-backed exploration
    batch linked to that review before resuming normal candidate flow.
@@ -160,71 +144,50 @@ A kept improvement, refreshed plot, updated report, local commit, first plateau
 check, or encoded `job.py` default is a checkpoint, not completion. Treat the
 campaign state as authoritative: if `final_response_allowed=false`, execute
 `next_action` and keep the same `job.py`, `autofl.yaml`, metric, environment,
-ledger, and comparison budget. Use
-[continuous-campaigns.md](references/continuous-campaigns.md) for simulator
-watchdogs, campaign-state handling, and recovery rules.
+ledger, and comparison budget. See
+[continuous-campaigns.md](references/continuous-campaigns.md) for watchdogs,
+campaign-state handling, and recovery rules.
 
 ## Candidate Caps
 
 Campaigns are uncapped by default. If the user says "optimize this job" without
-an explicit candidate budget, continue the campaign until manually interrupted
-or blocked. Do not stop after the first baseline, first batch, first successful
-candidate, first kept improvement, first local commit, or first plateau
-checkpoint. Do not stop after a first sweep of tunables; broaden into
-agent-authored code or literature-derived algorithm candidates. Uncapped progress
-reports must not ask whether to continue; continue unless the
-user explicitly interrupts or the code-owned state permits finalization.
-Do not invent a replacement campaign or new objective after a recoverable
-failure. Keep the current campaign identity and artifacts coherent unless the
-human explicitly requests a new campaign.
+an explicit candidate budget, continue until manually interrupted or blocked.
+Do not stop after the first baseline, batch, successful candidate, kept
+improvement, local commit, plateau checkpoint, or sweep of tunables; broaden
+into agent-authored code or literature-derived algorithm candidates. Uncapped
+progress reports must not ask whether to continue; continue unless the user
+explicitly interrupts or the code-owned state permits finalization. Do not
+invent a replacement campaign or new objective after a recoverable failure;
+keep the campaign identity and artifacts coherent unless the human explicitly
+requests a new campaign.
 
 If the user provides an `N`-candidate budget, pass it only through the runner's
 explicit `--max-candidates` argument and count up to `N` comparable attempts
 after baseline. Never infer a cap from an inherited environment variable. Do
 not count import, validation, smoke runs, plotting, reporting, baseline, or
-infrastructure-only retries. Count a real candidate crash after execution
+infrastructure-only retries; count a real candidate crash after execution
 starts. State must report `candidate_cap_source=explicit` or `uncapped`.
 
-Treat plateau as a decision checkpoint, not an automatic stop. Summarize the
-plateau in the running report, refresh `progress.png`, run the runner's `status`
-action to refresh `.nvflare/autofl/campaign_state.json`, choose the returned
-next mode, and continue unless the state reports `final_response_allowed=true`.
-Use `campaign_guard.py` only for read-only ledger diagnostics; it never updates
+Treat plateau as a decision checkpoint, not an automatic stop: summarize it in
+the running report, refresh `progress.png`, run the runner's `status` action to
+refresh `.nvflare/autofl/campaign_state.json`, choose the returned next mode,
+and continue unless the state reports `final_response_allowed=true`. Use
+`campaign_guard.py` only for read-only ledger diagnostics; it never updates
 authoritative campaign state.
-After a source-backed review, record it with the helper's `record --literature
---hypothesis "<sources and decision>"` action before preparing its candidates.
-Each recorded review gets a persistent `literature_event_id` (`lit-0001` style).
-
-## Literature Exploration Batches
-
-A recorded literature review requires an exploration batch:
-`exploration_batch_size` (default 3, flag `--exploration-batch-size`, env
-`AUTOFL_EXPLORATION_BATCH_SIZE`) scored source-backed candidates linked to that
-review via `prepare --literature-event <id>` before normal candidate flow
-resumes. Campaign state keeps `next_action=develop_literature_batch` and
-`required_exploration=source_backed_exploration` until the batch completes.
-Compose the batch as a faithful implementation of the literature idea, a tuned
-variant, and an ablation. Every literature-linked candidate must contain
-source edits; the runner rejects argument-only literature-linked candidates at
-evaluate time.
-
-The plateau clock resets only when the exploration batch completes — when its
-final linked candidate scores — not when the review row is recorded. Recording
-a review does not relieve plateau pressure. After the first literature event,
-if the last `family_repeat_limit` (default 6, flag `--family-repeat-limit`,
-env `AUTOFL_FAMILY_REPEAT_LIMIT`, 0 disables) scored attempts are all
-argument-only tuning of the same algorithm family, campaign state sets
-`next_action=diversify_candidates`: switch to a different algorithm family or
-prepare a source-backed candidate.
-
-Select literature ideas for the workload, not only for server aggregation:
-client optimizer, loss function, learning-rate schedule, and architecture
-changes within the fixed comparison budget all qualify as source-backed
-exploration. Match the workload's threat model: do not select Byzantine-robust
-aggregation (geometric median, trimmed mean, sign gating, bucketed median) for
-benign-client campaigns, where it predictably sacrifices accuracy with no
-adversary present. If no source-backed exploration is compatible with the job
-contract, record the reason in the literature event.
+After a source-backed review, record it with `record --literature
+--hypothesis "<sources and decision>"`. Each review gets a persistent
+`literature_event_id` and requires an exploration batch before normal flow
+resumes: `exploration_batch_size` (default 3) scored source-backed candidates
+linked via `prepare --literature-event <id>` — a faithful implementation, a
+tuned variant, and an ablation. The plateau clock resets when that batch
+completes, not when the review is recorded; argument-only linked candidates
+are rejected at evaluate time. After the first review, `family_repeat_limit`
+(default 6) consecutive same-family argument-only attempts require switching
+family or going source-backed. Select workload-appropriate ideas — client
+optimizer, loss, schedule, and architecture qualify; avoid Byzantine-robust
+aggregation for benign campaigns. If no source-backed exploration is
+compatible, record why in the event. Flags, env vars, and full semantics:
+[continuous-campaigns.md](references/continuous-campaigns.md).
 
 ## Stop Handling
 


### PR DESCRIPTION
## Summary

Follow-up to #15: the exploration-batch additions pushed `skills/nvflare-autofl/SKILL.md` to 236 lines, failing `skill-md-size-lint` (v1 hard limit 200). Found while verifying the evals/references layout question against the admission checks.

## What changed

- Condensed the "Literature Exploration Batches" section to the enforced mechanics, pointing at `references/continuous-campaigns.md` (which already carries the flags, env vars, and full semantics).
- Tightened surrounding prose without dropping any normative rule — every anti-stop enumeration, cap rule, and threat-model instruction is preserved, just phrased more compactly.
- SKILL.md is now **199 lines**.

## Validation

- `python -m dev_tools.agent.skills.checks --skills-root skills` → **0 errors, 0 warnings** (was 1 error).
- 41 packaging + skill-check + guard + plot tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)