### PR TITLE
Harden Auto-FL import and runner across hello-world jobs

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -18,9 +18,8 @@ Use this skill when the user asks to optimize an existing NVFLARE `job.py` for a
 AUC, loss, runtime, robustness, or another metric in simulation, POC, or production.
 
 ## Do Not Use When
-Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs
-without an optimization goal, production deployment setup, or generic hyperparameter
-tuning outside an NVFLARE job.
+Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs without an optimization goal,
+production deployment setup, evaluation/statistics-only recipes, or generic tuning outside an NVFLARE job.
 
 ## Workflow
 Use this skill to optimize an existing NVFLARE `job.py` without asking the user to learn
@@ -35,6 +34,8 @@ Resolve [run_job_campaign.py](scripts/run_job_campaign.py) relative to this `SKI
 ```bash
 python "$RUNNER" initialize ./job.py [--metric <metric>] --mode <max|min> --env <sim|poc|prod> [--max-candidates <n>]
 ```
+
+For conditional recipes, safe refusals, and unnamed simulator roots, read the [job import contract](references/job-import-contract.md).
 
 Read `autofl.yaml` and the JSON response, then prepare an agent-authored candidate with a short hypothesis and optional candidate-only arguments:
 

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -1,0 +1,22 @@
+# Job Import Contract
+
+The importer parses `job.py` without executing it. When the job selects its
+training recipe through CLI control flow, pass the same fixed selector to the
+runner through `--base-args`, for example:
+
+```bash
+python "$RUNNER" initialize ./job.py --base-args "--mode training" [other options]
+```
+
+The importer applies recognized argparse overrides while resolving simple
+`if`/`elif` branches, and the runner preserves those arguments for every
+baseline and candidate. Evaluation-only, statistics-only, and unsupported
+nested-application recipes stop during import with an actionable
+`import.support.reason`; they must not start a baseline.
+
+For simulator recipes without a literal name, the runner serializes discovery
+within that simulator workspace. It accepts a standard printed result path or
+the sole changed direct child of the workspace, validates that the root cannot
+escape the simulator directory, and persists the discovered name for cleanup,
+stall monitoring, and subsequent candidates. Ambiguous or out-of-workspace
+results fail closed.

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -27,7 +27,7 @@ import hashlib
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import yaml
 
@@ -36,6 +36,8 @@ IMPORTER_VERSION = "nvflare-autofl-job-importer/v1"
 ALLOWED_CREATE_PATTERNS = ["**/*.py"]
 
 SUPPORTED_ENV_NAMES = {"PocEnv", "ProdEnv", "SimEnv"}
+NON_OPTIMIZATION_RECIPE_NAMES = {"FedEvalRecipe", "FedStatsRecipe", "NumpyCrossSiteEvalRecipe"}
+UNSUPPORTED_NESTED_RECIPE_NAMES = {"FlowerRecipe"}
 TUNABLE_ARG_NAMES = {
     "aggregation_epochs",
     "alpha",
@@ -114,6 +116,7 @@ class DeterministicJobImporter:
         mode: str = "max",
         target_env: Optional[str] = None,
         max_candidates: Optional[int] = None,
+        job_args: Optional[Sequence[str]] = None,
     ) -> Dict[str, Any]:
         """Return an ``autofl.yaml``-shaped config for ``job_path``.
 
@@ -123,6 +126,8 @@ class DeterministicJobImporter:
             mode: ``max`` or ``min`` objective direction.
             target_env: Optional target environment, such as ``sim`` or ``prod``.
             max_candidates: Optional fixed candidate budget.
+            job_args: Optional job CLI arguments used to resolve argparse defaults
+                and simple conditional recipe branches.
 
         Returns:
             A deterministic, YAML-serializable mapping.
@@ -139,9 +144,11 @@ class DeterministicJobImporter:
             raise JobImportError(f"failed to parse {source_path}: {e}") from e
 
         index = _ImportIndex.from_tree(tree, source_text)
-        job_call = index.first_job_call()
-        env_call = index.first_env_call()
-        train_script = self._resolve_train_script(source_path, job_call, index, source_text)
+        parser_args = _parser_args_with_cli_overrides(index.parser_args, job_args or [])
+        reachable_functions = _reachable_function_names(tree, parser_args)
+        job_call = index.first_job_call(reachable_functions)
+        env_call = index.first_env_call(reachable_functions)
+        train_script = self._resolve_train_script(source_path, job_call, index, parser_args, source_text)
         train_args = _collect_argparse_args_from_file(train_script) if train_script else {}
         unresolved: List[Dict[str, str]] = []
 
@@ -154,19 +161,22 @@ class DeterministicJobImporter:
                     "its contract cannot be imported deterministically"
                 )
             unresolved.append(_unresolved("job.surface", reason))
+        support_status, support_reason = _support_status(job_call)
+        if support_reason and job_call:
+            unresolved.append(_unresolved("job.surface", support_reason))
         if not train_script:
             unresolved.append(_unresolved("job.train_script", "no train_script was found or resolved"))
 
-        metric_name, metric_source, metric_issue = self._resolve_metric(metric, job_call, index.parser_args)
+        metric_name, metric_source, metric_issue = self._resolve_metric(metric, job_call, parser_args)
         objective = _objective_contract(metric_name, mode, metric_source)
         if metric_issue:
             unresolved.append(metric_issue)
 
-        budget, budget_issues = self._resolve_budget(max_candidates, job_call, env_call, index.parser_args, source_text)
+        budget, budget_issues = self._resolve_budget(max_candidates, job_call, env_call, parser_args, source_text)
         unresolved.extend(budget_issues)
 
         allowed_edit_paths = self._allowed_edit_paths(source_path, train_script)
-        search_space, search_issues = self._suggest_search_space(index.parser_args, train_args)
+        search_space, search_issues = self._suggest_search_space(parser_args, train_args)
         unresolved.extend(search_issues)
 
         job_payload = {
@@ -175,7 +185,7 @@ class DeterministicJobImporter:
             "entrypoint": "main" if _has_main_entrypoint(tree) else "unresolved",
         }
         if job_call:
-            call_args, call_issues = self._resolved_call_keywords(job_call, index.parser_args, source_text)
+            call_args, call_issues = self._resolved_call_keywords(job_call, parser_args, source_text)
             unresolved.extend(call_issues)
             if _is_recipe_call(job_call):
                 job_payload.update(
@@ -196,9 +206,9 @@ class DeterministicJobImporter:
         if train_script:
             job_payload["train_script"] = self._display_path(train_script)
 
-        environment = self._environment_profile(target_env, env_call, index.parser_args, source_text)
+        environment = self._environment_profile(target_env, env_call, parser_args, source_text)
         if env_call:
-            env_args, env_issues = self._resolved_call_keywords(env_call, index.parser_args, source_text)
+            env_args, env_issues = self._resolved_call_keywords(env_call, parser_args, source_text)
             unresolved.extend(env_issues)
             environment["discovered"] = {"name": env_call.name, "args": env_args}
 
@@ -210,8 +220,9 @@ class DeterministicJobImporter:
                 "source_sha256": _sha256_text(source_text),
                 "confidence": _overall_confidence(unresolved, job_call),
                 "support": {
-                    "status": "supported" if job_call else "partial",
+                    "status": support_status,
                     "patterns": _support_patterns(job_call, env_call),
+                    **({"reason": support_reason} if support_reason else {}),
                 },
             },
             "job": job_payload,
@@ -273,6 +284,7 @@ class DeterministicJobImporter:
         source_path: Path,
         job_call: Optional[CallInfo],
         index: "_ImportIndex",
+        parser_args: Dict[str, ArgSpec],
         source_text: str,
     ) -> Optional[Path]:
         if not job_call:
@@ -280,7 +292,7 @@ class DeterministicJobImporter:
 
         train_script_node = job_call.keywords.get("train_script")
         if train_script_node:
-            resolved = _resolve_value(train_script_node, job_call.assignments, index.parser_args, source_text)
+            resolved = _resolve_value(train_script_node, job_call.assignments, parser_args, source_text)
             value = resolved.value
             if isinstance(value, str) and _is_resolved_path_string(resolved):
                 return _existing_path((source_path.parent / value).resolve())
@@ -291,7 +303,7 @@ class DeterministicJobImporter:
             script_node = runner_call.keywords.get("script")
             if not script_node:
                 continue
-            resolved = _resolve_value(script_node, runner_call.assignments, index.parser_args, source_text)
+            resolved = _resolve_value(script_node, runner_call.assignments, parser_args, source_text)
             if isinstance(resolved.value, str) and _is_resolved_path_string(resolved):
                 path = _existing_path((source_path.parent / resolved.value).resolve())
                 if path:
@@ -469,6 +481,7 @@ def import_job_to_autofl_config(
     mode: str = "max",
     target_env: Optional[str] = None,
     max_candidates: Optional[int] = None,
+    job_args: Optional[Sequence[str]] = None,
 ) -> Dict[str, Any]:
     """Convenience wrapper for deterministic job import."""
 
@@ -479,6 +492,7 @@ def import_job_to_autofl_config(
         mode=mode,
         target_env=target_env,
         max_candidates=max_candidates,
+        job_args=job_args,
     )
 
 
@@ -514,11 +528,11 @@ class _ImportIndex(ast.NodeVisitor):
         index.visit(tree)
         return index
 
-    def first_job_call(self) -> Optional[CallInfo]:
-        return self.job_calls[0] if self.job_calls else None
+    def first_job_call(self, reachable_functions: Optional[Set[str]] = None) -> Optional[CallInfo]:
+        return _first_reachable_call(self.job_calls, reachable_functions)
 
-    def first_env_call(self) -> Optional[CallInfo]:
-        return self.env_calls[0] if self.env_calls else None
+    def first_env_call(self, reachable_functions: Optional[Set[str]] = None) -> Optional[CallInfo]:
+        return _first_reachable_call(self.env_calls, reachable_functions)
 
     def first_unsupported_job_call(self) -> Optional[CallInfo]:
         return self.unsupported_job_calls[0] if self.unsupported_job_calls else None
@@ -634,6 +648,153 @@ class _ImportIndex(ast.NodeVisitor):
         if self._local_assignments_stack:
             assignments.update(self._local_assignments_stack[-1])
         return assignments
+
+
+def _first_reachable_call(calls: Sequence[CallInfo], reachable_functions: Optional[Set[str]]) -> Optional[CallInfo]:
+    if not calls:
+        return None
+    if len(calls) == 1 or reachable_functions is None:
+        return calls[0]
+    reachable_calls = [
+        call for call in calls if call.function_name is None or call.function_name in reachable_functions
+    ]
+    return reachable_calls[0] if reachable_calls else None
+
+
+def _parser_args_with_cli_overrides(parser_args: Dict[str, ArgSpec], job_args: Sequence[str]) -> Dict[str, ArgSpec]:
+    resolved = dict(parser_args)
+    flags = {flag: spec for spec in parser_args.values() for flag in spec.flags}
+    index = 0
+    while index < len(job_args):
+        token = job_args[index]
+        flag, separator, inline_value = token.partition("=")
+        spec = flags.get(flag)
+        if spec is None:
+            index += 1
+            continue
+
+        if spec.action in {"store_true", "store_false"}:
+            value = spec.action == "store_true"
+            consumed = 1
+        elif separator:
+            value = _coerce_cli_value(inline_value, spec)
+            consumed = 1
+        elif index + 1 < len(job_args):
+            value = _coerce_cli_value(job_args[index + 1], spec)
+            consumed = 2
+        else:
+            index += 1
+            continue
+
+        resolved[spec.name] = ArgSpec(
+            name=spec.name,
+            flags=spec.flags,
+            default=value,
+            default_source="job_cli_arg",
+            value_type=spec.value_type,
+            choices=spec.choices,
+            action=spec.action,
+        )
+        index += consumed
+    return resolved
+
+
+def _coerce_cli_value(value: str, spec: ArgSpec) -> Any:
+    value_type = (spec.value_type or "").split(".")[-1]
+    try:
+        if value_type == "int":
+            return int(value)
+        if value_type == "float":
+            return float(value)
+    except ValueError:
+        return value
+    return value
+
+
+def _reachable_function_names(tree: ast.AST, parser_args: Dict[str, ArgSpec]) -> Set[str]:
+    functions = {
+        node.name: node
+        for node in getattr(tree, "body", [])
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    if "main" not in functions:
+        return set(functions)
+
+    arg_values = {name: spec.default for name, spec in parser_args.items() if not spec.default_unresolved}
+    reachable = set()
+    pending = ["main"]
+    while pending:
+        name = pending.pop()
+        if name in reachable or name not in functions:
+            continue
+        reachable.add(name)
+        called = _called_functions(functions[name].body, arg_values)
+        pending.extend(sorted((called & functions.keys()) - reachable, reverse=True))
+    return reachable
+
+
+def _called_functions(statements: Sequence[ast.stmt], arg_values: Dict[str, Any]) -> Set[str]:
+    calls: Set[str] = set()
+    for statement in statements:
+        if isinstance(statement, ast.If):
+            condition = _static_condition_value(statement.test, arg_values)
+            if condition is True:
+                calls.update(_called_functions(statement.body, arg_values))
+            elif condition is False:
+                calls.update(_called_functions(statement.orelse, arg_values))
+            else:
+                calls.update(_called_functions(statement.body, arg_values))
+                calls.update(_called_functions(statement.orelse, arg_values))
+            continue
+        collector = _DirectCallCollector()
+        collector.visit(statement)
+        calls.update(collector.names)
+    return calls
+
+
+class _DirectCallCollector(ast.NodeVisitor):
+    def __init__(self):
+        self.names: Set[str] = set()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Name):
+            self.names.add(node.func.id)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        return
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
+
+def _static_condition_value(node: ast.AST, arg_values: Dict[str, Any]) -> Optional[bool]:
+    if isinstance(node, ast.Compare) and len(node.ops) == 1 and len(node.comparators) == 1:
+        left_known, left = _static_condition_operand(node.left, arg_values)
+        right_known, right = _static_condition_operand(node.comparators[0], arg_values)
+        if not left_known or not right_known:
+            return None
+        if isinstance(node.ops[0], ast.Eq):
+            return left == right
+        if isinstance(node.ops[0], ast.NotEq):
+            return left != right
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        value = _static_condition_value(node.operand, arg_values)
+        return None if value is None else not value
+    return None
+
+
+def _static_condition_operand(node: ast.AST, arg_values: Dict[str, Any]) -> Tuple[bool, Any]:
+    is_literal, value = _literal_value(node)
+    if is_literal:
+        return True, value
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "args":
+        if node.attr in arg_values:
+            return True, arg_values[node.attr]
+    return False, None
 
 
 def _collect_argparse_args_from_file(path: Optional[Path]) -> Dict[str, ArgSpec]:
@@ -848,6 +1009,22 @@ def _surface_name(call_info: Optional[CallInfo]) -> str:
     if not call_info:
         return "unknown"
     return "recipe" if _is_recipe_call(call_info) else "fed_job"
+
+
+def _support_status(job_call: Optional[CallInfo]) -> Tuple[str, Optional[str]]:
+    if not job_call:
+        return "partial", "no supported Recipe or NVFlare FedJob constructor was found"
+    if job_call.name in NON_OPTIMIZATION_RECIPE_NAMES:
+        return (
+            "partial",
+            f"{job_call.name} is evaluation/statistics-only and has no training loop for Auto-FL optimization",
+        )
+    if job_call.name in UNSUPPORTED_NESTED_RECIPE_NAMES:
+        return (
+            "partial",
+            f"{job_call.name} wraps a nested application whose training source cannot be imported deterministically",
+        )
+    return "supported", None
 
 
 def _env_name_to_profile(env_name: str) -> str:

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -23,6 +23,7 @@ discarded candidates, and records reproducible campaign state and artifacts.
 from __future__ import annotations
 
 import argparse
+import ast
 import codecs
 import csv
 import difflib
@@ -46,6 +47,11 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback keeps per-root locks
+    fcntl = None
 
 try:
     import yaml
@@ -967,9 +973,11 @@ def extract_result_dir(output: str, cwd: Optional[Path] = None) -> Optional[Path
         r"Result can be found in\s*:\s*(?P<path>\S+)",
         r"Results:\s*(?P<path>\S+)",
         r"result_dir=(?P<path>\S+)",
+        r"result location\s*[:=]\s*(?P<path>\S+)",
+        r"simulation logs can be found at\s+(?P<path>\S+)",
     ]
     for pattern in patterns:
-        match = re.search(pattern, output)
+        match = re.search(pattern, output, flags=re.IGNORECASE)
         if match:
             path = Path(match.group("path")).expanduser()
             if not path.is_absolute() and cwd is not None:
@@ -1084,20 +1092,51 @@ def text_metric_matches(text: str, metric: str) -> List[Tuple[int, float]]:
     number = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
     context = r"(?:(?:final|test|validation|cross[-_ ]site)\s+)*"
     line_prefix = r"^\s*(?:\[[^\]]+\]\s*)*(?:\{|\[)?\s*"
-    pattern = re.compile(
+    direct_pattern = re.compile(
         line_prefix + rf"{context}[\"']?{re.escape(metric)}[\"']?" rf"\s*[:=]\s*({number})(?:\s|[,}}\]]|$)",
         flags=re.IGNORECASE,
     )
-    matches = []
+    evaluation_pattern = re.compile(
+        rf"\b{re.escape(metric)}\s+of\s+the\s+received\s+model\b.*?:\s*({number})(?:\s*%|\s|$)",
+        flags=re.IGNORECASE,
+    )
+    framework_pattern = re.compile(
+        rf"(?<![\w]){re.escape(metric)}(?![\w])\s*[:=]\s*({number})(?:\s|[,}}\]]|$)",
+        flags=re.IGNORECASE,
+    )
+    mapping_pattern = re.compile(
+        rf"(?:\{{|,)\s*[\"']{re.escape(metric)}[\"']\s*:\s*({number})(?:\s|[,}}]|$)",
+        flags=re.IGNORECASE,
+    )
+    direct_matches = []
+    evaluation_matches = []
+    mapping_matches = []
+    framework_matches = []
     for line_number, line in enumerate(text.splitlines(), start=1):
-        message = line.rsplit(" - ", 1)[-1]
-        match = pattern.search(message)
-        if not match:
-            continue
-        score = parse_finite_metric_value(match.group(1))
-        if score is not None:
-            matches.append((line_number, score))
-    return matches
+        log_prefix = re.match(r"^\d{4}-\d{2}-\d{2}[^\n]*? - [A-Z]+ - (.*)$", line)
+        message = log_prefix.group(1) if log_prefix else line
+        direct_match = direct_pattern.search(message)
+        if direct_match:
+            score = parse_finite_metric_value(direct_match.group(1))
+            if score is not None:
+                direct_matches.append((line_number, score))
+        evaluation_match = evaluation_pattern.search(message)
+        if evaluation_match:
+            score = parse_finite_metric_value(evaluation_match.group(1))
+            if score is not None:
+                evaluation_matches.append((line_number, score))
+        mapping_match = mapping_pattern.search(message)
+        if mapping_match:
+            score = parse_finite_metric_value(mapping_match.group(1))
+            if score is not None:
+                mapping_matches.append((line_number, score))
+        if re.search(r"\d+/\d+.*\d+(?:\.\d+)?(?:ms|s)/step\b", message):
+            matches = list(framework_pattern.finditer(message))
+            if matches:
+                score = parse_finite_metric_value(matches[-1].group(1))
+                if score is not None:
+                    framework_matches.append((line_number, score))
+    return evaluation_matches or direct_matches or mapping_matches or framework_matches
 
 
 def extract_metric_evidence(artifact_root: Path, metrics: Sequence[str] | str) -> Optional[MetricEvidence]:
@@ -1183,19 +1222,22 @@ def collect_artifacts(result_dir: Optional[Path], output_root: Path, name: str, 
 
 
 def job_help(python: str, job: Path, cwd: Path, timeout: int = DEFAULT_JOB_HELP_TIMEOUT) -> str:
+    del python, cwd, timeout
     try:
-        process = subprocess.run(
-            [python, str(job), "--help"],
-            cwd=str(cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            check=False,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired as e:
-        raise RuntimeError(f"job.py --help exceeded {timeout} seconds") from e
-    return process.stdout
+        tree = ast.parse(job.read_text(encoding="utf-8"), filename=str(job))
+    except (OSError, SyntaxError) as e:
+        raise RuntimeError(f"cannot inspect job CLI flags in {job}: {e}") from e
+    flags = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "add_argument":
+            continue
+        for argument in node.args:
+            if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+                if argument.value.startswith("--"):
+                    flags.add(argument.value)
+    return " ".join(sorted(flags))
 
 
 def supported_long_flags(help_text: str) -> set[str]:
@@ -1619,6 +1661,9 @@ def imported_job_names(config: Dict[str, Any]) -> List[str]:
             continue
         if isinstance(value, str) and value and value not in names:
             names.append(value)
+    discovered_name = config.get("artifacts", {}).get("simulator_result_name")
+    if isinstance(discovered_name, str) and discovered_name and discovered_name not in names:
+        names.append(discovered_name)
     return names
 
 
@@ -1678,6 +1723,55 @@ def locked_simulator_roots(roots: Sequence[Path]) -> Iterator[None]:
             lock_path.unlink(missing_ok=True)
 
 
+@contextmanager
+def locked_simulator_workspace(simulator_base: Path, *, exclusive: bool) -> Iterator[None]:
+    """Coordinate unknown result roots with named jobs in the same simulator workspace."""
+
+    if fcntl is None:
+        yield
+        return
+    simulator_base.mkdir(parents=True, exist_ok=True)
+    lock_path = simulator_base / ".autofl-workspace.lock"
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    try:
+        try:
+            fcntl.flock(descriptor, operation | fcntl.LOCK_NB)
+        except BlockingIOError as e:
+            mode = "unnamed" if exclusive else "named"
+            raise RuntimeError(
+                f"simulator workspace is already in use by a conflicting {mode} campaign: {simulator_base}"
+            ) from e
+        yield
+    finally:
+        os.close(descriptor)
+
+
+def validated_printed_simulator_root(result_dir: Optional[Path], simulator_base: Path) -> Optional[Path]:
+    if result_dir is None or not result_dir.exists():
+        return None
+    resolved = result_dir.resolve()
+    if resolved.parent != simulator_base.resolve():
+        return None
+    return resolved
+
+
+def simulator_root_snapshot(simulator_base: Path) -> Dict[Path, int]:
+    snapshot = {}
+    if not simulator_base.exists():
+        return snapshot
+    for path in simulator_base.iterdir():
+        if path.name.startswith(".") or path.is_symlink() or not path.is_dir():
+            continue
+        snapshot[path.resolve()] = path.stat().st_mtime_ns
+    return snapshot
+
+
+def changed_simulator_roots(simulator_base: Path, before: Dict[Path, int]) -> List[Path]:
+    after = simulator_root_snapshot(simulator_base)
+    return sorted(path for path, modified in after.items() if before.get(path) != modified)
+
+
 def run_job(
     run_def: JobRun,
     *,
@@ -1698,33 +1792,40 @@ def run_job(
     run_name = simulator_run_name(run_def.name, cwd)
     name_args = ["--name", run_name] if supports_flag(help_text, "--name") else []
     simulator_roots = expected_simulator_roots(config, run_name if name_args else None, cwd)
-    if not simulator_roots:
-        raise ValueError(
-            "cannot resolve a deterministic simulator result root; expose a literal job name or support --name"
-        )
+    simulator_base = simulator_workspace_root(config, cwd)
     command = [python, str(job), *fixed_args, *base_args, *name_args, *run_def.args]
     run_def.command = command
-    with locked_simulator_roots(simulator_roots):
-        for simulator_root in simulator_roots:
-            shutil.rmtree(simulator_root, ignore_errors=True)
-        rc, stdout, runtime = run(
-            command,
-            cwd,
-            timeout,
-            log_path,
-            simulator_stall_roots=simulator_roots,
-            simulator_no_progress_timeout=simulator_no_progress_timeout,
-        )
-        run_def.runtime_seconds = runtime
-        printed_result_dir = extract_result_dir(stdout, cwd)
-        existing_roots = [root.resolve() for root in simulator_roots if root.exists()]
-        result_dir = printed_result_dir if printed_result_dir in existing_roots else None
-        injected_root = (simulator_workspace_root(config, cwd) / run_name).resolve() if name_args else None
-        if result_dir is None and injected_root in existing_roots:
-            result_dir = injected_root
-        if result_dir is None and len(existing_roots) == 1:
-            result_dir = existing_roots[0]
-        artifact_dir = collect_artifacts(result_dir, output_root, run_def.name, log_path)
+    with locked_simulator_workspace(simulator_base, exclusive=not simulator_roots):
+        with locked_simulator_roots(simulator_roots):
+            unnamed_root_snapshot = simulator_root_snapshot(simulator_base) if not simulator_roots else {}
+            for simulator_root in simulator_roots:
+                shutil.rmtree(simulator_root, ignore_errors=True)
+            rc, stdout, runtime = run(
+                command,
+                cwd,
+                timeout,
+                log_path,
+                simulator_stall_roots=simulator_roots,
+                simulator_no_progress_timeout=simulator_no_progress_timeout,
+            )
+            run_def.runtime_seconds = runtime
+            printed_result_dir = extract_result_dir(stdout, cwd)
+            existing_roots = [root.resolve() for root in simulator_roots if root.exists()]
+            result_dir = printed_result_dir if printed_result_dir in existing_roots else None
+            injected_root = (simulator_base / run_name).resolve() if name_args else None
+            if result_dir is None and injected_root in existing_roots:
+                result_dir = injected_root
+            if result_dir is None and len(existing_roots) == 1:
+                result_dir = existing_roots[0]
+            if result_dir is None and not simulator_roots:
+                result_dir = validated_printed_simulator_root(printed_result_dir, simulator_base)
+                if result_dir is None:
+                    changed_roots = changed_simulator_roots(simulator_base, unnamed_root_snapshot)
+                    if len(changed_roots) == 1:
+                        result_dir = changed_roots[0]
+                if result_dir is not None:
+                    config.setdefault("artifacts", {})["simulator_result_name"] = result_dir.name
+            artifact_dir = collect_artifacts(result_dir, output_root, run_def.name, log_path)
     run_def.artifacts = str(artifact_dir)
 
     evidence = None
@@ -1745,7 +1846,7 @@ def run_job(
         run_def.status = "crash"
         run_def.failure_reason = (
             "job exited successfully but no deterministic NVFlare result directory was resolved; "
-            "expose literal SimEnv workspace_root and job name values"
+            "expose a literal job name, support --name, or print the direct simulator result directory"
         )
     else:
         artifact_root = artifact_dir.parent
@@ -2210,6 +2311,7 @@ def import_job_config(
         mode=args.mode,
         target_env=args.target_env,
         max_candidates=args.max_candidates,
+        job_args=shlex.split(args.base_args),
     )
     atomic_write_bytes(output, importer.dump_autofl_yaml(config).encode("utf-8"))
     atomic_write_bytes(
@@ -2235,7 +2337,8 @@ def campaign_admission_errors(config: Dict[str, Any]) -> List[str]:
     errors = []
     support = config.get("import", {}).get("support", {})
     if not isinstance(support, dict) or support.get("status") != "supported":
-        errors.append("job surface is not deterministically supported")
+        reason = support.get("reason") if isinstance(support, dict) else None
+        errors.append(f"job surface is not deterministically supported{f': {reason}' if reason else ''}")
     fixed_budget = config.get("budget", {}).get("fixed_training_budget")
     if not isinstance(fixed_budget, dict) or not fixed_budget:
         errors.append("fixed comparison budget is unresolved")
@@ -2375,6 +2478,7 @@ def initialize_campaign(args: argparse.Namespace, job: Path) -> int:
                 load_mutation_schema(workspace),
                 name=f"baseline_retry_{retry_number}",
             )
+            write_yaml(paths["autofl_yaml"], config)
             records.append(baseline)
             metadata["best_score"] = baseline.score
             if baseline.score is not None:
@@ -2426,6 +2530,7 @@ def initialize_campaign(args: argparse.Namespace, job: Path) -> int:
     records: List[RunRecord] = []
     if args.target_env == "sim":
         baseline = execute_sim_baseline(args, job, paths, config, schema)
+        write_yaml(paths["autofl_yaml"], config)
         records.append(baseline)
         metadata["best_score"] = baseline.score
         metadata["updated_at"] = utc_now()

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -646,6 +646,159 @@ MyRecipe(name="local", num_rounds=1, min_clients=2)
     assert config["job"]["surface"] == "unknown"
 
 
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["FedEvalRecipe", "FedStatsRecipe", "NumpyCrossSiteEvalRecipe"],
+)
+def test_import_refuses_non_optimization_recipes_before_execution(tmp_path, recipe_name):
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        f"""
+from nvflare.recipe import {recipe_name}
+
+{recipe_name}(name="not-training", min_clients=2)
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    support = config["import"]["support"]
+    assert support["status"] == "partial"
+    assert "no training loop" in support["reason"]
+    assert any(item["field"] == "job.surface" for item in config["unresolved"])
+
+
+def test_import_refuses_nested_flower_recipe_before_execution(tmp_path):
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_opt.flower.recipe import FlowerRecipe
+
+FlowerRecipe(name="flower", flower_content="app", min_clients=2)
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    support = config["import"]["support"]
+    assert support["status"] == "partial"
+    assert "nested application" in support["reason"]
+
+
+def test_import_selects_conditional_training_recipe_from_job_args(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+import argparse
+
+from nvflare.app_common.np.recipes import NumpyCrossSiteEvalRecipe, NumpyFedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+def define_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["pretrained", "training"], default="pretrained")
+    parser.add_argument("--n_clients", type=int, default=2)
+    parser.add_argument("--num_rounds", type=int, default=1)
+    return parser.parse_args()
+
+
+def run_eval(n_clients):
+    NumpyCrossSiteEvalRecipe(name="eval", min_clients=n_clients)
+    SimEnv(num_clients=n_clients)
+
+
+def run_training(n_clients, num_rounds):
+    NumpyFedAvgRecipe(
+        name="training",
+        min_clients=n_clients,
+        num_rounds=num_rounds,
+        train_script="client.py",
+    )
+    SimEnv(num_clients=n_clients)
+
+
+def main():
+    args = define_parser()
+    if args.mode == "pretrained":
+        run_eval(args.n_clients)
+    elif args.mode == "training":
+        run_training(args.n_clients, args.num_rounds)
+
+
+if __name__ == "__main__":
+    main()
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    default_config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+    training_config = import_job_to_autofl_config(
+        str(job_path),
+        workspace_root=str(tmp_path),
+        job_args=["--mode", "training", "--num_rounds=3"],
+    )
+
+    assert default_config["job"]["recipe"] == "NumpyCrossSiteEvalRecipe"
+    assert default_config["import"]["support"]["status"] == "partial"
+    assert training_config["job"]["recipe"] == "NumpyFedAvgRecipe"
+    assert training_config["job"]["train_script"] == "client.py"
+    assert training_config["import"]["support"]["status"] == "supported"
+    assert training_config["budget"]["fixed_training_budget"] == {
+        "num_rounds": 3,
+        "min_clients": 2,
+        "num_clients": 2,
+    }
+
+
+@pytest.mark.parametrize(
+    ("example", "expected_status", "expected_recipe"),
+    [
+        ("hello-cyclic", "supported", "CyclicRecipe"),
+        ("hello-lightning", "supported", "FedAvgRecipe"),
+        ("hello-lr", "supported", "FedAvgLrRecipe"),
+        ("hello-flower", "partial", "FlowerRecipe"),
+        ("hello-lightning-eval", "partial", "FedEvalRecipe"),
+        ("hello-numpy-cross-val", "partial", "NumpyCrossSiteEvalRecipe"),
+        ("hello-tabular-stats", "partial", "FedStatsRecipe"),
+        ("hello-tf", "supported", "FedAvgRecipe"),
+    ],
+)
+def test_import_classifies_hello_world_release_gate_examples(example, expected_status, expected_recipe):
+    repo_root = Path(__file__).parents[3]
+    example_root = repo_root / "examples" / "hello-world" / example
+
+    config = import_job_to_autofl_config(
+        str(example_root / "job.py"),
+        workspace_root=str(example_root),
+        metric="accuracy",
+        max_candidates=12,
+    )
+
+    assert config["import"]["support"]["status"] == expected_status
+    assert config["job"]["recipe"] == expected_recipe
+
+
+def test_import_selects_hello_numpy_cross_val_training_mode():
+    repo_root = Path(__file__).parents[3]
+    example_root = repo_root / "examples" / "hello-world" / "hello-numpy-cross-val"
+
+    config = import_job_to_autofl_config(
+        str(example_root / "job.py"),
+        workspace_root=str(example_root),
+        metric="weight_mean",
+        max_candidates=12,
+        job_args=["--mode", "training"],
+    )
+
+    assert config["import"]["support"]["status"] == "supported"
+    assert config["job"]["recipe"] == "NumpyFedAvgRecipe"
+    assert config["job"]["train_script"] == "client.py"
+
+
 def test_import_returns_clean_error_for_missing_job(tmp_path):
     with pytest.raises(job_importer.JobImportError, match="job.py not found"):
         import_job_to_autofl_config(str(tmp_path / "missing.py"), workspace_root=str(tmp_path))

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -329,6 +329,43 @@ def test_text_metric_extraction_ignores_trailing_contextual_mentions(tmp_path):
     assert evidence.source == "text:log.txt:line=1"
 
 
+def test_text_metric_extraction_supports_keras_progress_output(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("log.txt").write_text(
+        "938/938 - 3s - 3ms/step - accuracy: 0.9687 - loss: 0.0991 - val_accuracy: 0.9816\n",
+        encoding="utf-8",
+    )
+
+    assert runner.extract_score(tmp_path, ["accuracy"]) == pytest.approx(0.9687)
+
+
+def test_text_metric_extraction_prefers_nvflare_received_model_evaluation(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("log.txt").write_text(
+        """
+2026-07-08 16:25:18,029 - INFO - Accuracy of the received model on round 1 on the test images: 94.3 %
+938/938 - 3s - 3ms/step - accuracy: 0.9687 - loss: 0.0991
+2026-07-08 16:25:22,029 - INFO - Accuracy of the received model on round 2 on the test images: 98.2 %
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
+
+    assert evidence.score == pytest.approx(98.2)
+    assert evidence.source == "text:log.txt:line=3"
+
+
+def test_text_metric_extraction_supports_embedded_metrics_mapping(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("log.txt").write_text(
+        "validation metric scores on client: site-2 = {'accuracy': 0.764, 'precision': 0.64}\n",
+        encoding="utf-8",
+    )
+
+    assert runner.extract_score(tmp_path, ["accuracy"]) == pytest.approx(0.764)
+
+
 def test_runner_applies_schema_metric_contract():
     runner = _load_runner()
     config = {
@@ -440,13 +477,35 @@ def test_run_streams_partial_line_before_timeout(tmp_path):
     assert "partial output" in log_path.read_text(encoding="utf-8")
 
 
-def test_job_help_is_bounded(tmp_path):
+def test_job_help_discovers_flags_without_executing_job(tmp_path):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    marker = tmp_path / "executed"
+    job.write_text(
+        f"""
+import argparse
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--n_clients", type=int, default=2)
+parser.add_argument("-r", "--num_rounds", type=int, default=1)
+Path({str(marker)!r}).write_text("executed")
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    help_text = runner.job_help(sys.executable, job, tmp_path, timeout=1)
+
+    assert runner.supported_long_flags(help_text) == {"--n_clients", "--num_rounds"}
+    assert not marker.exists()
+
+
+def test_job_help_returns_no_flags_for_non_argparse_job(tmp_path):
     runner = _load_runner()
     job = tmp_path / "job.py"
     job.write_text("import time\ntime.sleep(30)\n", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="job.py --help exceeded 1 seconds"):
-        runner.job_help(sys.executable, job, tmp_path, timeout=1)
+    assert runner.job_help(sys.executable, job, tmp_path, timeout=1) == ""
 
 
 def test_metric_extraction_prefers_structured_artifacts_then_known_text_logs(tmp_path):
@@ -479,6 +538,10 @@ def test_result_paths_and_static_job_names_are_resolved_deterministically(tmp_pa
     }
 
     assert runner.extract_result_dir("Result can be found in : relative-result", tmp_path) == relative.resolve()
+    assert runner.extract_result_dir("result location = relative-result", tmp_path) == relative.resolve()
+    assert (
+        runner.extract_result_dir("The simulation logs can be found at relative-result", tmp_path) == relative.resolve()
+    )
     assert runner.imported_job_names(config) == ["recipe-name", "fed-job-name"]
     assert runner.expected_simulator_roots(config, "injected", tmp_path) == [
         (default_root / "injected").resolve(),
@@ -494,31 +557,187 @@ def test_result_paths_and_static_job_names_are_resolved_deterministically(tmp_pa
         runner.expected_simulator_roots({}, "../other-run", tmp_path)
 
 
-def test_run_without_deterministic_result_root_fails_before_execution(tmp_path, monkeypatch):
+def test_run_without_deterministic_result_root_records_actionable_failure(tmp_path, monkeypatch):
     runner = _load_runner()
     job = tmp_path / "job.py"
     job.write_text("print('done')\n", encoding="utf-8")
-    monkeypatch.setattr(
-        runner,
-        "run",
-        lambda *args, **kwargs: pytest.fail("unmonitored simulator jobs must not execute"),
+    monkeypatch.setattr(runner, "run", lambda *args, **kwargs: (0, "done\n", 0.1))
+
+    record = runner.run_job(
+        runner.JobRun("candidate", [], "candidate"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text="",
+        fixed_args=[],
+        base_args=[],
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["accuracy"],
+        config={"job": {}},
     )
 
-    with pytest.raises(ValueError, match="cannot resolve a deterministic simulator result root"):
-        runner.run_job(
-            runner.JobRun("candidate", [], "candidate"),
-            python=sys.executable,
-            job=job,
-            cwd=tmp_path,
-            help_text="",
-            fixed_args=[],
-            base_args=[],
-            output_root=tmp_path / "runs",
-            timeout=10,
-            simulator_no_progress_timeout=0,
-            metrics=["accuracy"],
-            config={"job": {}},
-        )
+    assert record.status == "crash"
+    assert "print the direct simulator result directory" in record.failure_reason
+
+
+def test_run_discovers_and_persists_printed_unnamed_simulator_root(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('job')\n", encoding="utf-8")
+    simulator_base = tmp_path / "simulation"
+    result = simulator_base / "recipe-default"
+
+    def fake_run(*args, **kwargs):
+        result.mkdir(parents=True)
+        result.joinpath("metrics_summary.json").write_text(json.dumps({"accuracy": 0.81}), encoding="utf-8")
+        return 0, f"The simulation logs can be found at {result}\n", 0.1
+
+    monkeypatch.setattr(runner, "run", fake_run)
+    config = {
+        "job": {},
+        "artifacts": {},
+        "environment": {
+            "discovered": {"args": {"workspace_root": {"value": str(simulator_base), "confidence": "high"}}}
+        },
+    }
+
+    record = runner.run_job(
+        runner.JobRun("baseline", [], "baseline", status="baseline"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text="",
+        fixed_args=[],
+        base_args=[],
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["accuracy"],
+        config=config,
+    )
+
+    assert record.status == "baseline"
+    assert record.score == pytest.approx(0.81)
+    assert config["artifacts"]["simulator_result_name"] == "recipe-default"
+    assert runner.expected_simulator_roots(config, None, tmp_path) == [result.resolve()]
+
+
+def test_run_discovers_single_changed_unnamed_simulator_root(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('job')\n", encoding="utf-8")
+    simulator_base = tmp_path / "simulation"
+    result = simulator_base / "recipe-default"
+
+    def fake_run(*args, **kwargs):
+        result.mkdir(parents=True)
+        result.joinpath("metrics_summary.json").write_text(json.dumps({"val_acc": 0.73}), encoding="utf-8")
+        return 0, "job complete without a result message\n", 0.1
+
+    monkeypatch.setattr(runner, "run", fake_run)
+    config = {
+        "job": {},
+        "artifacts": {},
+        "environment": {
+            "discovered": {"args": {"workspace_root": {"value": str(simulator_base), "confidence": "high"}}}
+        },
+    }
+
+    record = runner.run_job(
+        runner.JobRun("baseline", [], "baseline", status="baseline"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text="",
+        fixed_args=[],
+        base_args=[],
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["val_acc"],
+        config=config,
+    )
+
+    assert record.status == "baseline"
+    assert record.score == pytest.approx(0.73)
+    assert config["artifacts"]["simulator_result_name"] == "recipe-default"
+
+
+def test_run_rejects_ambiguous_changed_unnamed_simulator_roots(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('job')\n", encoding="utf-8")
+    simulator_base = tmp_path / "simulation"
+
+    def fake_run(*args, **kwargs):
+        for name in ("first", "second"):
+            result = simulator_base / name
+            result.mkdir(parents=True)
+            result.joinpath("metrics_summary.json").write_text(json.dumps({"accuracy": 0.5}), encoding="utf-8")
+        return 0, "ambiguous job complete\n", 0.1
+
+    monkeypatch.setattr(runner, "run", fake_run)
+    record = runner.run_job(
+        runner.JobRun("candidate", [], "candidate"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text="",
+        fixed_args=[],
+        base_args=[],
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["accuracy"],
+        config={
+            "job": {},
+            "environment": {
+                "discovered": {"args": {"workspace_root": {"value": str(simulator_base), "confidence": "high"}}}
+            },
+        },
+    )
+
+    assert record.status == "crash"
+    assert record.score is None
+
+
+def test_run_rejects_printed_result_outside_simulator_workspace(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('job')\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+
+    def fake_run(*args, **kwargs):
+        outside.mkdir()
+        return 0, f"Result can be found in : {outside}\n", 0.1
+
+    monkeypatch.setattr(runner, "run", fake_run)
+    record = runner.run_job(
+        runner.JobRun("candidate", [], "candidate"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text="",
+        fixed_args=[],
+        base_args=[],
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["accuracy"],
+        config={
+            "job": {},
+            "environment": {
+                "discovered": {
+                    "args": {"workspace_root": {"value": str(tmp_path / "simulation"), "confidence": "high"}}
+                }
+            },
+        },
+    )
+
+    assert record.status == "crash"
+    assert record.score is None
 
 
 def test_simulator_root_lock_rejects_concurrent_campaign(tmp_path):
@@ -531,6 +750,18 @@ def test_simulator_root_lock_rejects_concurrent_campaign(tmp_path):
                 pass
 
     assert not root.with_name(f".{root.name}.autofl.lock").exists()
+
+
+def test_simulator_workspace_lock_excludes_unnamed_and_named_campaigns(tmp_path):
+    runner = _load_runner()
+    if runner.fcntl is None:
+        pytest.skip("fcntl workspace locking is unavailable")
+    simulator_base = tmp_path / "simulation"
+
+    with runner.locked_simulator_workspace(simulator_base, exclusive=True):
+        with pytest.raises(RuntimeError, match="conflicting named campaign"):
+            with runner.locked_simulator_workspace(simulator_base, exclusive=False):
+                pass
 
 
 def test_run_job_collects_configured_sim_result_and_standard_nvflare_text_metric(tmp_path):
@@ -1621,10 +1852,11 @@ def test_import_job_config_forwards_minimization_mode(tmp_path, monkeypatch):
             return runner.yaml.safe_dump(config)
 
     monkeypatch.setattr(runner, "load_job_importer", lambda: FakeImporter)
-    args = runner.parse_args(["initialize", str(job), "--mode", "min"])
+    args = runner.parse_args(["initialize", str(job), "--mode", "min", "--base-args", "--mode training"])
     runner.import_job_config(args, job, output, tmp_path / "import.log", 10)
 
     assert captured["mode"] == "min"
+    assert captured["job_args"] == ["--mode", "training"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- resolve simple argparse-controlled recipe branches from `--base-args`, and safely refuse evaluation/statistics-only and nested Flower recipes before baseline execution
- discover CLI flags statically, serialize unnamed simulator-root discovery, validate and persist result roots, and retain per-root cleanup/watchdog behavior
- extract metrics from structured artifacts, NVFlare received-model messages, embedded metric dictionaries, and Keras progress output
- document the import contract and add regression coverage against the affected hello-world jobs

## Validation

- `pytest -q tests/unit_test/tool/autofl_skill_job_importer_test.py tests/unit_test/tool/autofl_skill_runner_test.py` — 128 passed
- `pytest -q tests/unit_test/tool/agent_skill_checks/frontmatter_test.py tests/unit_test/tool/agent/agent_skill_checks_test.py` — 47 passed
- `./runtest.sh -s --skip-install` — Black, isort, flake8, and agent-skill lint passed

### H100 end-to-end baseline reruns

| Job | Result |
|---|---:|
| hello-numpy-cross-val (`--mode training`) | `weight_mean=1.000000` |
| hello-cyclic | `accuracy=98.079997` |
| hello-lightning | `val_acc=0.286500` |
| hello-lr | `accuracy=0.778846` |
| hello-tf | `accuracy=0.962600` |

`hello-flower`, `hello-lightning-eval`, default `hello-numpy-cross-val`, and `hello-tabular-stats` all stopped during import with actionable reasons and no baseline log. The prior hello-tf failure reproduced as GPU-memory contention during the matrix run; its isolated H100 rerun completed successfully.