### PR TITLE
Align design doc with per-trial simulator isolation

### DIFF
--- a/docs/design/autofl_skill.md
+++ b/docs/design/autofl_skill.md
@@ -200,11 +200,16 @@ accepts only explicit metric-field or final-evaluation lines and records the
 selected line number. The ledger is replaced atomically so a failed write cannot
 leave a partial campaign record.
 
-Simulation runs use campaign-scoped result names and lock every deterministic
-simulator result root before cleanup and execution. A simulation that cannot
-resolve a monitored result root fails before launch. POC and production results
-are accepted only after the materialized candidate is re-imported and its fixed
-comparison budget is verified again.
+Each simulation trial runs in an isolated temporary simulator workspace that
+the runner injects through the process-level
+`NVFLARE_SIMULATOR_WORKSPACE_ROOT` override, so concurrent campaigns cannot
+share or delete each other's artifacts. Result names stay campaign-scoped and
+named result roots are locked during execution. A recipe without a literal job
+name may run, but its result root must resolve afterwards to the printed
+result path or the sole changed workspace child; ambiguous or out-of-workspace
+results fail closed. POC and production results are accepted only after the
+materialized candidate is re-imported and its fixed comparison budget is
+verified again.
 
 ## Skill Implementation Boundary
 


### PR DESCRIPTION
## Summary

Pre-merge doc-consistency fix found while sweeping the latest branch head: the design doc's simulator paragraph still described the pre-isolation mechanism and contradicted two behaviors that changed in PR #17 and the trial-isolation commit:

- "lock every deterministic simulator result root **before cleanup** and execution" — the pre-run `rmtree` cleanup was removed when trials moved to isolated temporary workspaces.
- "A simulation that cannot resolve a monitored result root **fails before launch**" — unnamed recipes now run and resolve their root afterwards (printed result path or sole changed workspace child), failing closed only on ambiguity.

The rewritten paragraph describes the `NVFLARE_SIMULATOR_WORKSPACE_ROOT` per-trial isolation, retained campaign-scoped names and root locks, and the fail-closed post-run discovery contract — keeping every design-doc claim verifiable against the implementation.

Doc-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)